### PR TITLE
Finally control-flow matrix and rework (return/break/continue)

### DIFF
--- a/crates/nu-engine/src/compile/builder.rs
+++ b/crates/nu-engine/src/compile/builder.rs
@@ -288,6 +288,7 @@ impl BlockBuilder {
             Instruction::FinallyInto { index: _, dst } => allocate(&[], &[*dst]),
             Instruction::PopErrorHandler => Ok(()),
             Instruction::PopFinallyRun => Ok(()),
+            Instruction::RunFinally => Ok(()),
             Instruction::ReturnEarly { src } => allocate(&[*src], &[]),
             Instruction::Return { src } => allocate(&[*src], &[]),
         };

--- a/crates/nu-engine/src/compile/keyword.rs
+++ b/crates/nu-engine/src/compile/keyword.rs
@@ -716,6 +716,10 @@ pub(crate) fn compile_try(
             }
             .into_spanned(call.head),
         )?;
+        // Marks the end of the `finally` block. On the success path this is a no-op; when a
+        // bail-out (`return`/error/exit) is pending, it resumes that bail-out instead of falling
+        // through into the code after the `try`.
+        builder.push(Instruction::RunFinally.into_spanned(call.head))?;
     }
 
     Ok(())

--- a/crates/nu-engine/src/eval_ir.rs
+++ b/crates/nu-engine/src/eval_ir.rs
@@ -305,6 +305,33 @@ fn eval_ir_block_impl<D: DebugContext>(
                     return Ok(ctx.take_reg(reg_id).with_early_return());
                 }
             }
+            Ok(InstructionResult::PopFinally) => {
+                // On the success path, pop the innermost `finally` handler as usual. While a
+                // bail-out is pending we must not pop: the handler being run was already popped by
+                // the bail-out arm, and the enclosing handlers must survive so `RunFinally` can
+                // resume through them.
+                if ret_val.is_none() {
+                    ctx.stack.finally_run_handlers.pop(ctx.finally_handler_base);
+                }
+                pc += 1;
+            }
+            Ok(InstructionResult::RunFinally) => {
+                // End of an inline `finally`. Nothing to do on the success path. If a bail-out is
+                // pending, resume it: run the next enclosing `finally`, or leave the block with the
+                // pending value once none remain.
+                if ret_val.is_some() {
+                    if let Some(always_run_handler) =
+                        ctx.stack.finally_run_handlers.pop(ctx.finally_handler_base)
+                    {
+                        prepare_error_handler(ctx, always_run_handler, None);
+                        pc = always_run_handler.handler_index;
+                    } else {
+                        return ret_val.take().expect("ret_val was just checked to be Some");
+                    }
+                } else {
+                    pc += 1;
+                }
+            }
             Err(err @ (ShellError::Continue { .. } | ShellError::Break { .. })) => {
                 return Err(err);
             }
@@ -418,6 +445,13 @@ enum InstructionResult {
     /// invocations clear the flag instead, so a `return` in a nested call can't leak out and be
     /// mistaken for a `return` at the current level.
     ReturnEarly(RegId),
+    /// Pop the innermost `finally` handler (the `pop-finally` instruction). While a bail-out is
+    /// pending this is a no-op, so the enclosing handlers survive for the bail-out to resume.
+    PopFinally,
+    /// End of an inline `finally` block (the `run-finally` instruction). On the success path this
+    /// is a no-op; while a bail-out is pending it resumes it, running the next enclosing `finally`
+    /// or leaving the block with the pending value.
+    RunFinally,
 }
 
 /// Perform an instruction
@@ -1054,10 +1088,8 @@ fn eval_instruction<D: DebugContext>(
             ctx.stack.error_handlers.pop(ctx.error_handler_base);
             Ok(Continue)
         }
-        Instruction::PopFinallyRun => {
-            ctx.stack.finally_run_handlers.pop(ctx.finally_handler_base);
-            Ok(Continue)
-        }
+        Instruction::PopFinallyRun => Ok(InstructionResult::PopFinally),
+        Instruction::RunFinally => Ok(InstructionResult::RunFinally),
         Instruction::ReturnEarly { src } => Ok(InstructionResult::ReturnEarly(*src)),
         Instruction::Return { src } => Ok(Return(*src)),
     }

--- a/crates/nu-engine/src/eval_ir.rs
+++ b/crates/nu-engine/src/eval_ir.rs
@@ -450,7 +450,8 @@ enum InstructionResult {
     PopFinally,
     /// End of an inline `finally` block (the `run-finally` instruction). On the success path this
     /// is a no-op; while a bail-out is pending it resumes it, running the next enclosing `finally`
-    /// or leaving the block with the pending value.
+    /// or leaving the block with the pending value. A `return` that leaves this way keeps its
+    /// early-return flag, so it still reads as a `return` at the current level.
     RunFinally,
 }
 

--- a/crates/nu-protocol/src/ir/display.rs
+++ b/crates/nu-protocol/src/ir/display.rs
@@ -268,6 +268,9 @@ impl fmt::Display for FmtInstruction<'_> {
             Instruction::PopFinallyRun => {
                 write!(f, "{:WIDTH$}", "pop-finally")
             }
+            Instruction::RunFinally => {
+                write!(f, "{:WIDTH$}", "run-finally")
+            }
             Instruction::ReturnEarly { src } => {
                 write!(f, "{:WIDTH$} {src}", "return-early")
             }

--- a/crates/nu-protocol/src/ir/mod.rs
+++ b/crates/nu-protocol/src/ir/mod.rs
@@ -266,6 +266,10 @@ pub enum Instruction {
     PopErrorHandler,
     /// Pop an finally handler.
     PopFinallyRun,
+    /// Marks the end of an inline `finally` block. On the normal (success) path this is a no-op.
+    /// When a bail-out (`return`/error/exit) is pending, it resumes that bail-out: it runs the
+    /// next enclosing `finally`, or leaves the block with the pending value once none remain.
+    RunFinally,
     /// Return early from the block with the value in the register.
     ///
     /// Unlike `return`, this runs pending `finally` handlers first (collecting the value in that
@@ -349,6 +353,7 @@ impl Instruction {
             Instruction::FinallyInto { .. } => None,
             Instruction::PopErrorHandler => None,
             Instruction::PopFinallyRun => None,
+            Instruction::RunFinally => None,
             Instruction::ReturnEarly { .. } => None,
             Instruction::Return { .. } => None,
         }

--- a/tests/eval/mod.rs
+++ b/tests/eval/mod.rs
@@ -522,27 +522,39 @@ fn early_return_in_module_export_env_does_not_abort_caller() {
 // ===================================================================================
 // Control-flow signals through `finally`: behavior matrix
 //
-// A control-flow signal (`return`, `break`, `continue`) that leaves a block should run any
-// pending `finally` blocks on the way out, and then keep leaving: it must not run the code
-// that sits after the `try`/`finally`, and it must not be swallowed.
+// Markers printed by each case: F = finally ran, I/O = inner/outer finally, C = catch ran,
+// A = code after the try ran, D = code after a loop ran. Trailing letter(s) = the returned
+// value. So "FV" means: finally ran, then the command returned "V".
 //
-// Markers printed by each case: F = finally ran, C = catch ran, A = code-after-the-try ran,
-// I/O = inner/outer finally, D = code after a loop ran. Trailing letter(s) = the value the
-// command returned. So "FV" means: finally ran, then the command returned "V".
+// Group A: a signal in the `try` (return / break / continue) should run any pending `finally`
+// on the way out, then keep leaving. It must not run the code after the try/finally, and it
+// must not be swallowed.
 //
-//   # | case                                   | main (current) | expected | status
-//  ---+----------------------------------------+----------------+----------+--------
-//   1 | return, try/finally, code after        | FAV            | FV       | BUG: `A` runs
-//   2 | return, try/catch/finally, code after  | FAV            | FV       | BUG: `A` runs
-//   3 | return, try/catch, code after          | V              | V        | ok (guard)
-//   4 | return, try/finally, in tail position  | FV             | FV       | ok (guard)
-//   5 | return, nested finally, code after     | IOAV           | IOV      | BUG: `A` runs
-//   6 | break, loop + try/finally              | D              | FD       | BUG: finally skipped
-//   7 | continue, loop + try/finally           | D              | FFD      | BUG: finally skipped
+//   1  return, try/finally, code after           main FAV   want FV    BUG: A runs
+//      def foo [] { try { return "V" } finally { print -n "F" }; print -n "A"; "T" }; foo
+//   2  return, try/catch/finally, code after      main FAV   want FV    BUG: A runs
+//      def foo [] { try { return "V" } catch { print -n "C" } finally { print -n "F" }; print -n "A"; "T" }; foo
+//   3  return, try/catch, code after   (guard)     main V     want V     ok
+//      def foo [] { try { return "V" } catch { print -n "C" }; print -n "A"; "T" }; foo
+//   4  return, try/finally, tail       (guard)     main FV    want FV    ok
+//      def foo [] { try { return "V" } finally { print -n "F" } }; foo
+//   5  return, nested finally, code after          main IOAV  want IOV   BUG: A runs
+//      def foo [] { try { try { return "V" } finally { print -n "I" } } finally { print -n "O" }; print -n "A"; "T" }; foo
+//   6  break, loop + try/finally                   main D     want FD    BUG: finally skipped
+//      for x in [1] { try { break } finally { print -n "F" } }; print -n "D"
+//   7  continue, loop + try/finally                main D     want FFD   BUG: finally skipped
+//      for x in [1 2] { try { continue } finally { print -n "F" } }; print -n "D"
 //
-// The `main (current)` column was confirmed by running each case on the base commit. Cases
-// 1, 2, 5, 6 and 7 are currently wrong; they are marked `#[ignore]` until the finally rework
-// lands, at which point the ignore is removed and the assertion holds.
+// Group B: when the `finally` itself bails out, its own signal overrides whatever the `try`
+// left pending. This already works and is unchanged by the rework; the guards lock it in.
+//
+//   8  finally returns, over a pending return (guard)   want 7
+//      def foo [] { try { return 5 } finally { return 7 } }; foo
+//   9  finally errors, over a pending return  (guard)   want the finally's error
+//      def foo [] { try { return 5 } finally { error make { msg: "from finally" } } }; foo
+//
+// The `main` columns were confirmed by running each case on the base commit. Cases 1, 2, 5, 6
+// and 7 are wrong today and are marked `#[ignore]` until the finally rework lands.
 
 #[test]
 #[ignore = "BUG (matrix #1): `return` through a finally still runs the code after the try"]
@@ -604,6 +616,24 @@ fn finally_runs_on_continue() {
     test_eval(
         r#"for x in [1 2] { try { continue } finally { print -n "F" } }; print -n "D""#,
         Eq("FFD"),
+    )
+}
+
+#[test]
+fn finally_return_overrides_pending_return() {
+    // 8 (guard): a `return` in the finally wins over a `return` pending from the try.
+    test_eval(
+        r#"def foo [] { try { return 5 } finally { return 7 } }; foo"#,
+        Eq("7"),
+    )
+}
+
+#[test]
+fn finally_error_overrides_pending_return() {
+    // 9 (guard): an error in the finally wins over a `return` pending from the try.
+    test_eval(
+        r#"def foo [] { try { return 5 } finally { error make { msg: "from finally" } } }; foo"#,
+        Error("from finally"),
     )
 }
 

--- a/tests/eval/mod.rs
+++ b/tests/eval/mod.rs
@@ -623,7 +623,7 @@ fn finally_runs_on_continue() {
 fn finally_return_overrides_pending_return() {
     // 8 (guard): a `return` in the finally wins over a `return` pending from the try.
     test_eval(
-        r#"def foo [] { try { return 5 } finally { return 7 } }; foo"#,
+        "def foo [] { try { return 5 } finally { return 7 } }; foo",
         Eq("7"),
     )
 }

--- a/tests/eval/mod.rs
+++ b/tests/eval/mod.rs
@@ -519,6 +519,94 @@ fn early_return_in_module_export_env_does_not_abort_caller() {
     });
 }
 
+// ===================================================================================
+// Control-flow signals through `finally`: behavior matrix
+//
+// A control-flow signal (`return`, `break`, `continue`) that leaves a block should run any
+// pending `finally` blocks on the way out, and then keep leaving: it must not run the code
+// that sits after the `try`/`finally`, and it must not be swallowed.
+//
+// Markers printed by each case: F = finally ran, C = catch ran, A = code-after-the-try ran,
+// I/O = inner/outer finally, D = code after a loop ran. Trailing letter(s) = the value the
+// command returned. So "FV" means: finally ran, then the command returned "V".
+//
+//   # | case                                   | main (current) | expected | status
+//  ---+----------------------------------------+----------------+----------+--------
+//   1 | return, try/finally, code after        | FAV            | FV       | BUG: `A` runs
+//   2 | return, try/catch/finally, code after  | FAV            | FV       | BUG: `A` runs
+//   3 | return, try/catch, code after          | V              | V        | ok (guard)
+//   4 | return, try/finally, in tail position  | FV             | FV       | ok (guard)
+//   5 | return, nested finally, code after     | IOAV           | IOV      | BUG: `A` runs
+//   6 | break, loop + try/finally              | D              | FD       | BUG: finally skipped
+//   7 | continue, loop + try/finally           | D              | FFD      | BUG: finally skipped
+//
+// The `main (current)` column was confirmed by running each case on the base commit. Cases
+// 1, 2, 5, 6 and 7 are currently wrong; they are marked `#[ignore]` until the finally rework
+// lands, at which point the ignore is removed and the assertion holds.
+
+#[test]
+#[ignore = "BUG (matrix #1): `return` through a finally still runs the code after the try"]
+fn finally_return_skips_code_after() {
+    test_eval(
+        r#"def foo [] { try { return "V" } finally { print -n "F" }; print -n "A"; "T" }; foo | print"#,
+        Eq("FV"),
+    )
+}
+
+#[test]
+#[ignore = "BUG (matrix #2): `return` through catch+finally still runs the code after the try"]
+fn finally_return_with_catch_skips_code_after() {
+    test_eval(
+        r#"def foo [] { try { return "V" } catch { print -n "C" } finally { print -n "F" }; print -n "A"; "T" }; foo | print"#,
+        Eq("FV"),
+    )
+}
+
+#[test]
+fn return_with_catch_no_finally_skips_code_after() {
+    // guard: without a finally, `return` already skips the code after the try.
+    test_eval(
+        r#"def foo [] { try { return "V" } catch { print -n "C" }; print -n "A"; "T" }; foo | print"#,
+        Eq("V"),
+    )
+}
+
+#[test]
+fn finally_return_in_tail_runs_finally() {
+    // guard: the common case, `return` last in the body, keeps working.
+    test_eval(
+        r#"def foo [] { try { return "V" } finally { print -n "F" } }; foo | print"#,
+        Eq("FV"),
+    )
+}
+
+#[test]
+#[ignore = "BUG (matrix #5): `return` through nested finallys still runs the code after the try"]
+fn finally_return_runs_nested_finallys_then_skips_code_after() {
+    test_eval(
+        r#"def foo [] { try { try { return "V" } finally { print -n "I" } } finally { print -n "O" }; print -n "A"; "T" }; foo | print"#,
+        Eq("IOV"),
+    )
+}
+
+#[test]
+#[ignore = "BUG (matrix #6): `break` skips a pending finally"]
+fn finally_runs_on_break() {
+    test_eval(
+        r#"for x in [1] { try { break } finally { print -n "F" } }; print -n "D""#,
+        Eq("FD"),
+    )
+}
+
+#[test]
+#[ignore = "BUG (matrix #7): `continue` skips a pending finally"]
+fn finally_runs_on_continue() {
+    test_eval(
+        r#"for x in [1 2] { try { continue } finally { print -n "F" } }; print -n "D""#,
+        Eq("FFD"),
+    )
+}
+
 #[test]
 fn try_no_catch() {
     test_eval("try { error make { msg: foo } }; 'pass'", Eq("pass"))

--- a/tests/eval/mod.rs
+++ b/tests/eval/mod.rs
@@ -553,11 +553,13 @@ fn early_return_in_module_export_env_does_not_abort_caller() {
 //   9  finally errors, over a pending return  (guard)   want the finally's error
 //      def foo [] { try { return 5 } finally { error make { msg: "from finally" } } }; foo
 //
-// The `main` columns were confirmed by running each case on the base commit. Cases 1, 2, 5, 6
-// and 7 are wrong today and are marked `#[ignore]` until the finally rework lands.
+// The `main` columns were confirmed by running each case on the base commit. Cases 1, 2 and 5
+// (return through a finally) are fixed by the `run-finally` rework in this change. Cases 6 and 7
+// (break/continue through a finally) are a separate, compiler-level fix and stay `#[ignore]`
+// for a follow-up: unlike `return`, they compile to a direct jump out of the loop, so routing
+// them through a pending finally is a change in `compile/keyword.rs`, not the eval loop.
 
 #[test]
-#[ignore = "BUG (matrix #1): `return` through a finally still runs the code after the try"]
 fn finally_return_skips_code_after() {
     test_eval(
         r#"def foo [] { try { return "V" } finally { print -n "F" }; print -n "A"; "T" }; foo | print"#,
@@ -566,7 +568,6 @@ fn finally_return_skips_code_after() {
 }
 
 #[test]
-#[ignore = "BUG (matrix #2): `return` through catch+finally still runs the code after the try"]
 fn finally_return_with_catch_skips_code_after() {
     test_eval(
         r#"def foo [] { try { return "V" } catch { print -n "C" } finally { print -n "F" }; print -n "A"; "T" }; foo | print"#,
@@ -593,7 +594,6 @@ fn finally_return_in_tail_runs_finally() {
 }
 
 #[test]
-#[ignore = "BUG (matrix #5): `return` through nested finallys still runs the code after the try"]
 fn finally_return_runs_nested_finallys_then_skips_code_after() {
     test_eval(
         r#"def foo [] { try { try { return "V" } finally { print -n "I" } } finally { print -n "O" }; print -n "A"; "T" }; foo | print"#,


### PR DESCRIPTION
## Description

This is a spike on top of the early-return branch. It documents how control-flow signals behave when they leave a block through a `finally`, and pins that down with tests.

A `return`, `break`, or `continue` that leaves a block should run any pending `finally` on the way out, and then keep leaving. It should not run the code that sits after the `try`/`finally`, and it should not be swallowed. Today neither of those holds in all cases.

The matrix below was confirmed by running each case on the base commit (main). Markers: F = finally ran, C = catch ran, A = code after the try ran, I/O = inner/outer finally, D = code after a loop ran. The trailing letters are the returned value.

| # | case | main (current) | expected | status |
|---|------|----------------|----------|--------|
| 1 | return, try/finally, code after | `FAV` | `FV` | BUG: `A` runs |
| 2 | return, try/catch/finally, code after | `FAV` | `FV` | BUG: `A` runs |
| 3 | return, try/catch, code after | `V` | `V` | ok (guard) |
| 4 | return, try/finally, tail position | `FV` | `FV` | ok (guard) |
| 5 | return, nested finally, code after | `IOAV` | `IOV` | BUG: `A` runs |
| 6 | break, loop + try/finally | `D` | `FD` | BUG: finally skipped |
| 7 | continue, loop + try/finally | `D` | `FFD` | BUG: finally skipped |

So `return` runs too much (the code after the try) and `break`/`continue` run too little (they skip the finally entirely).

This commit adds the seven cases as unit tests, plus two group-B guards for the case where the finally itself bails out (its signal overrides a pending one; this already works). The two group-A guards pass. The five broken cases are marked `#[ignore]` with a note pointing at the bug, so the suite stays green while the behavior is documented. The follow-up commits (the finally rework that runs the finally as a sub-block) remove each ignore as the case starts passing.

## Root cause

Reading the compiled IR for the nested case shows why a small fix does not work. On a `return` through `try { try { return } finally { I } } finally { O }`:

- `return-early` pops the inner finally handler and jumps into the inner finally.
- The inner finally begins with `pop-finally`, which pops the outer handler too. By the time the inner finally runs, the finally handler stack is already empty.
- The finallys then chain only by compiled fall-through jumps (inner finally jumps to outer finally, which falls straight into the code after the try).

So after the last finally there is nothing that says "a bail-out is pending, leave now". The handler stack is empty, so a resume-check placed after each finally cannot tell the inner finally (keep going, outer still pending) from the outer finally (leave now). The information was already erased.

## Fix design: run the finally as a sub-block

Instead of jumping into the inline finally and chaining by fall-through, the bail-out path pops each pending finally handler and evaluates its block, innermost first, then propagates the original signal. Nesting falls out naturally and there is no fall-through into the code after the try. `break` and `continue`, which today return immediately without running any finally, go through the same path. This also removes the `ret_val` stash on the early-return branch.

The mechanics: the finally handler carries the finally block id (added to `ErrorHandler`), so the bail-out arms can evaluate it directly rather than jumping to an inline copy.

## User-facing changes (Release notes)

n/a (spike; no behavior change yet)

## Additional notes

Targets the `return-direction-2` branch so the two changes can be reviewed together. Not aimed at `nushell/nushell` yet.
