### PR TITLE
Run inner `finally` before an enclosing `catch`, on one unified handler stack

### DIFF
--- a/crates/nu-engine/src/compile/builder.rs
+++ b/crates/nu-engine/src/compile/builder.rs
@@ -295,6 +295,7 @@ impl BlockBuilder {
             Instruction::PopFinallyRun => Ok(()),
             Instruction::RunFinally => Ok(()),
             Instruction::ReturnEarly { src } => allocate(&[*src], &[]),
+            Instruction::JumpEarly { .. } => Ok(()),
             Instruction::Return { src } => allocate(&[*src], &[]),
         };
 
@@ -496,28 +497,37 @@ impl BlockBuilder {
         self.context_stack.is_in_loop()
     }
 
-    /// Add a loop breaking jump instruction.
-    pub(crate) fn push_break(&mut self, span: Span) -> Result<(), CompileError> {
+    /// Emit a `jump-early` for `break` (`is_break`) or `continue`: run the `finally_count` pending
+    /// `finally` blocks between here and the loop, then jump to the loop's break or continue label.
+    /// `supersedes` is set when this exit leaves a `finally`, so it discards a pending return/error.
+    pub(crate) fn push_loop_exit(
+        &mut self,
+        is_break: bool,
+        finally_count: usize,
+        supersedes: bool,
+        span: Span,
+    ) -> Result<(), CompileError> {
         let loop_ = self
             .context_stack
             .current_loop()
             .ok_or_else(|| CompileError::NotInALoop {
-                msg: "`break` called from outside of a loop".into(),
+                msg: "loop control used outside of a loop".into(),
                 span: Some(span),
             })?;
-        self.jump(loop_.break_label, span)
-    }
-
-    /// Add a loop continuing jump instruction.
-    pub(crate) fn push_continue(&mut self, span: Span) -> Result<(), CompileError> {
-        let loop_ = self
-            .context_stack
-            .current_loop()
-            .ok_or_else(|| CompileError::NotInALoop {
-                msg: "`continue` called from outside of a loop".into(),
-                span: Some(span),
-            })?;
-        self.jump(loop_.continue_label, span)
+        let index = if is_break {
+            loop_.break_label
+        } else {
+            loop_.continue_label
+        }
+        .0;
+        self.push(
+            Instruction::JumpEarly {
+                index,
+                finally_count,
+                supersedes,
+            }
+            .into_spanned(span),
+        )
     }
 
     /// Pop the loop state. Checks that the loop being ended is the same one that was expected.
@@ -596,15 +606,29 @@ impl BlockBuilder {
         })
     }
 
-    pub(crate) fn begin_try(&mut self) {
-        self.context_stack.push_try();
+    pub(crate) fn begin_try(&mut self, has_error_handler: bool, has_finally: bool) {
+        self.context_stack.push_try(has_error_handler, has_finally);
     }
 
     pub(crate) fn end_try(&mut self) -> Result<(), CompileError> {
         match self.context_stack.pop() {
-            Some(ContextBlock::Try) => Ok(()),
+            Some(ContextBlock::Try { .. }) => Ok(()),
             _ => Err(CompileError::NotInATry {
                 msg: "end_try() called outside of a try block".into(),
+                span: None,
+            }),
+        }
+    }
+
+    pub(crate) fn begin_finally(&mut self) {
+        self.context_stack.push_finally();
+    }
+
+    pub(crate) fn end_finally(&mut self) -> Result<(), CompileError> {
+        match self.context_stack.pop() {
+            Some(ContextBlock::Finally) => Ok(()),
+            _ => Err(CompileError::NotInATry {
+                msg: "end_finally() called outside of a finally block".into(),
                 span: None,
             }),
         }
@@ -622,7 +646,16 @@ pub(crate) struct Loop {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum ContextBlock {
     Loop(Loop),
-    Try,
+    /// A `try` block. Records which runtime handlers it pushed, so a `break`/`continue` leaving the
+    /// enclosing loop knows how many error handlers to pop and how many `finally` blocks to run on
+    /// the way out.
+    Try {
+        has_error_handler: bool,
+        has_finally: bool,
+    },
+    /// The body of a `finally` block. A `break`/`continue` that crosses this to reach its loop is
+    /// leaving the finally, so it supersedes any `return`/error whose finally is running.
+    Finally,
 }
 
 #[derive(Debug, Clone)]
@@ -637,8 +670,15 @@ impl ContextStack {
         self.0.push(ContextBlock::Loop(r#loop));
     }
 
-    pub fn push_try(&mut self) {
-        self.0.push(ContextBlock::Try);
+    pub fn push_try(&mut self, has_error_handler: bool, has_finally: bool) {
+        self.0.push(ContextBlock::Try {
+            has_error_handler,
+            has_finally,
+        });
+    }
+
+    pub fn push_finally(&mut self) {
+        self.0.push(ContextBlock::Finally);
     }
 
     pub fn pop(&mut self) -> Option<ContextBlock> {
@@ -652,12 +692,50 @@ impl ContextStack {
         })
     }
 
-    pub fn try_block_depth_from_loop(&self) -> usize {
+    /// The blocks between here and the nearest enclosing loop, innermost first. A `break`/`continue`
+    /// unwinds these on its way to the loop.
+    fn frames_to_loop(&self) -> impl Iterator<Item = &ContextBlock> + '_ {
         self.0
             .iter()
             .rev()
-            .take_while(|&cb| matches!(cb, ContextBlock::Try))
+            .take_while(|cb| !matches!(cb, ContextBlock::Loop(_)))
+    }
+
+    /// How many error handlers a `break`/`continue` must pop to reach its loop.
+    pub fn error_handler_depth_from_loop(&self) -> usize {
+        self.frames_to_loop()
+            .filter(|cb| {
+                matches!(
+                    cb,
+                    ContextBlock::Try {
+                        has_error_handler: true,
+                        ..
+                    }
+                )
+            })
             .count()
+    }
+
+    /// How many `finally` blocks a `break`/`continue` must run to reach its loop.
+    pub fn finally_depth_from_loop(&self) -> usize {
+        self.frames_to_loop()
+            .filter(|cb| {
+                matches!(
+                    cb,
+                    ContextBlock::Try {
+                        has_finally: true,
+                        ..
+                    }
+                )
+            })
+            .count()
+    }
+
+    /// Whether a `break`/`continue` leaves a `finally` block to reach its loop. If so, it supersedes
+    /// any `return`/error whose finally is currently running.
+    pub fn crosses_finally_to_loop(&self) -> bool {
+        self.frames_to_loop()
+            .any(|cb| matches!(cb, ContextBlock::Finally))
     }
 
     pub fn is_in_loop(&self) -> bool {

--- a/crates/nu-engine/src/compile/builder.rs
+++ b/crates/nu-engine/src/compile/builder.rs
@@ -293,6 +293,7 @@ impl BlockBuilder {
             Instruction::FinallyInto { index: _, dst } => allocate(&[], &[*dst]),
             Instruction::PopErrorHandler => Ok(()),
             Instruction::PopFinallyRun => Ok(()),
+            Instruction::RunFinally => Ok(()),
             Instruction::ReturnEarly { src } => allocate(&[*src], &[]),
             Instruction::Return { src } => allocate(&[*src], &[]),
         };

--- a/crates/nu-engine/src/compile/builder.rs
+++ b/crates/nu-engine/src/compile/builder.rs
@@ -497,13 +497,14 @@ impl BlockBuilder {
         self.context_stack.is_in_loop()
     }
 
-    /// Emit a `jump-early` for `break` (`is_break`) or `continue`: run the `finally_count` pending
-    /// `finally` blocks between here and the loop, then jump to the loop's break or continue label.
-    /// `supersedes` is set when this exit leaves a `finally`, so it discards a pending return/error.
+    /// Emit a `jump-early` for `break` (`is_break`) or `continue`: unwind the `handler_count`
+    /// `catch`/`finally` handlers between here and the loop (running the finallys, discarding the
+    /// catches), then jump to the loop's break or continue label. `supersedes` is set when this
+    /// exit leaves a `finally`, so it discards a pending return/error.
     pub(crate) fn push_loop_exit(
         &mut self,
         is_break: bool,
-        finally_count: usize,
+        handler_count: usize,
         supersedes: bool,
         span: Span,
     ) -> Result<(), CompileError> {
@@ -523,7 +524,7 @@ impl BlockBuilder {
         self.push(
             Instruction::JumpEarly {
                 index,
-                finally_count,
+                handler_count,
                 supersedes,
             }
             .into_spanned(span),
@@ -606,29 +607,49 @@ impl BlockBuilder {
         })
     }
 
-    pub(crate) fn begin_try(&mut self, has_error_handler: bool, has_finally: bool) {
-        self.context_stack.push_try(has_error_handler, has_finally);
+    /// Mark that a `catch` handler is now pending on the runtime stack (emitted an `on-error`).
+    pub(crate) fn begin_pending_catch(&mut self) {
+        self.context_stack.push_pending_catch();
     }
 
-    pub(crate) fn end_try(&mut self) -> Result<(), CompileError> {
+    /// Mark that the pending `catch` handler has been popped (emitted a `pop-error-handler`).
+    pub(crate) fn end_pending_catch(&mut self) -> Result<(), CompileError> {
         match self.context_stack.pop() {
-            Some(ContextBlock::Try { .. }) => Ok(()),
+            Some(ContextBlock::PendingCatch) => Ok(()),
             _ => Err(CompileError::NotInATry {
-                msg: "end_try() called outside of a try block".into(),
+                msg: "end_pending_catch() called out of order".into(),
                 span: None,
             }),
         }
     }
 
-    pub(crate) fn begin_finally(&mut self) {
-        self.context_stack.push_finally();
+    /// Mark that a `finally` handler is now pending on the runtime stack (emitted a `finally`).
+    pub(crate) fn begin_pending_finally(&mut self) {
+        self.context_stack.push_pending_finally();
     }
 
-    pub(crate) fn end_finally(&mut self) -> Result<(), CompileError> {
+    /// Mark that the pending `finally` handler has been popped (emitted a `pop-finally`).
+    pub(crate) fn end_pending_finally(&mut self) -> Result<(), CompileError> {
         match self.context_stack.pop() {
-            Some(ContextBlock::Finally) => Ok(()),
+            Some(ContextBlock::PendingFinally) => Ok(()),
             _ => Err(CompileError::NotInATry {
-                msg: "end_finally() called outside of a finally block".into(),
+                msg: "end_pending_finally() called out of order".into(),
+                span: None,
+            }),
+        }
+    }
+
+    /// Mark the start of compiling a `finally` block's body.
+    pub(crate) fn begin_finally_body(&mut self) {
+        self.context_stack.push_finally_body();
+    }
+
+    /// Mark the end of compiling a `finally` block's body.
+    pub(crate) fn end_finally_body(&mut self) -> Result<(), CompileError> {
+        match self.context_stack.pop() {
+            Some(ContextBlock::FinallyBody) => Ok(()),
+            _ => Err(CompileError::NotInATry {
+                msg: "end_finally_body() called outside of a finally block".into(),
                 span: None,
             }),
         }
@@ -643,19 +664,21 @@ pub(crate) struct Loop {
 }
 
 /// Blocks that modify/define behavior for the instructions they contain.
+///
+/// `PendingCatch` and `PendingFinally` mirror the runtime handler stack: each is active for exactly
+/// the span in which its handler sits on that stack, so a `break`/`continue` can count how many
+/// handlers it must unwind to reach its loop. A `catch` spans only the `try` body; a `finally`
+/// spans the body and the `catch`, so a `break` inside a `catch` still runs that `try`'s `finally`.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum ContextBlock {
     Loop(Loop),
-    /// A `try` block. Records which runtime handlers it pushed, so a `break`/`continue` leaving the
-    /// enclosing loop knows how many error handlers to pop and how many `finally` blocks to run on
-    /// the way out.
-    Try {
-        has_error_handler: bool,
-        has_finally: bool,
-    },
+    /// A `catch` handler is pending on the runtime stack (spans the `try` body).
+    PendingCatch,
+    /// A `finally` handler is pending on the runtime stack (spans the `try` body and its `catch`).
+    PendingFinally,
     /// The body of a `finally` block. A `break`/`continue` that crosses this to reach its loop is
     /// leaving the finally, so it supersedes any `return`/error whose finally is running.
-    Finally,
+    FinallyBody,
 }
 
 #[derive(Debug, Clone)]
@@ -670,15 +693,16 @@ impl ContextStack {
         self.0.push(ContextBlock::Loop(r#loop));
     }
 
-    pub fn push_try(&mut self, has_error_handler: bool, has_finally: bool) {
-        self.0.push(ContextBlock::Try {
-            has_error_handler,
-            has_finally,
-        });
+    pub fn push_pending_catch(&mut self) {
+        self.0.push(ContextBlock::PendingCatch);
     }
 
-    pub fn push_finally(&mut self) {
-        self.0.push(ContextBlock::Finally);
+    pub fn push_pending_finally(&mut self) {
+        self.0.push(ContextBlock::PendingFinally);
+    }
+
+    pub fn push_finally_body(&mut self) {
+        self.0.push(ContextBlock::FinallyBody);
     }
 
     pub fn pop(&mut self) -> Option<ContextBlock> {
@@ -701,31 +725,14 @@ impl ContextStack {
             .take_while(|cb| !matches!(cb, ContextBlock::Loop(_)))
     }
 
-    /// How many error handlers a `break`/`continue` must pop to reach its loop.
-    pub fn error_handler_depth_from_loop(&self) -> usize {
+    /// How many `catch`/`finally` handlers a `break`/`continue` must unwind (running the finallys,
+    /// discarding the catches) to reach its loop.
+    pub fn handler_depth_from_loop(&self) -> usize {
         self.frames_to_loop()
             .filter(|cb| {
                 matches!(
                     cb,
-                    ContextBlock::Try {
-                        has_error_handler: true,
-                        ..
-                    }
-                )
-            })
-            .count()
-    }
-
-    /// How many `finally` blocks a `break`/`continue` must run to reach its loop.
-    pub fn finally_depth_from_loop(&self) -> usize {
-        self.frames_to_loop()
-            .filter(|cb| {
-                matches!(
-                    cb,
-                    ContextBlock::Try {
-                        has_finally: true,
-                        ..
-                    }
+                    ContextBlock::PendingCatch | ContextBlock::PendingFinally
                 )
             })
             .count()
@@ -735,7 +742,7 @@ impl ContextStack {
     /// any `return`/error whose finally is currently running.
     pub fn crosses_finally_to_loop(&self) -> bool {
         self.frames_to_loop()
-            .any(|cb| matches!(cb, ContextBlock::Finally))
+            .any(|cb| matches!(cb, ContextBlock::FinallyBody))
     }
 
     pub fn is_in_loop(&self) -> bool {

--- a/crates/nu-engine/src/compile/keyword.rs
+++ b/crates/nu-engine/src/compile/keyword.rs
@@ -571,7 +571,7 @@ pub(crate) fn compile_try(
         pushed_error_handler = true;
     };
 
-    builder.begin_try();
+    builder.begin_try(pushed_error_handler, finally_type.is_some());
 
     if let Some(finally_info) = &finally_type {
         if finally_info.var_id.is_some() {
@@ -701,6 +701,7 @@ pub(crate) fn compile_try(
                 .into_spanned(call.head),
             )?;
         }
+        builder.begin_finally();
         compile_block(
             working_set,
             builder,
@@ -709,6 +710,7 @@ pub(crate) fn compile_try(
             Some(io_reg),
             io_reg,
         )?;
+        builder.end_finally()?;
         builder.push(
             Instruction::Move {
                 dst: io_reg,
@@ -1027,19 +1029,7 @@ pub(crate) fn compile_break(
     _input_reg: Option<RegId>,
     io_reg: RegId,
 ) -> Result<(), CompileError> {
-    if !builder.is_in_loop() {
-        return Err(CompileError::NotInALoop {
-            msg: "'break' can only be used inside a loop".to_string(),
-            span: Some(call.head),
-        });
-    }
-    builder.load_empty(io_reg)?;
-    for _ in 0..builder.context_stack.try_block_depth_from_loop() {
-        builder.push(Instruction::PopErrorHandler.into_spanned(call.head))?;
-    }
-    builder.push_break(call.head)?;
-    builder.add_comment("break");
-    Ok(())
+    compile_loop_exit(builder, call, io_reg, true)
 }
 
 /// Compile a call to `continue`.
@@ -1051,18 +1041,32 @@ pub(crate) fn compile_continue(
     _input_reg: Option<RegId>,
     io_reg: RegId,
 ) -> Result<(), CompileError> {
+    compile_loop_exit(builder, call, io_reg, false)
+}
+
+/// Compile a `break` (`is_break`) or `continue`: leave the enclosing loop, first popping the error
+/// handlers and running the `finally` blocks of every `try` block between here and the loop.
+fn compile_loop_exit(
+    builder: &mut BlockBuilder,
+    call: &Call,
+    io_reg: RegId,
+    is_break: bool,
+) -> Result<(), CompileError> {
+    let keyword = if is_break { "break" } else { "continue" };
     if !builder.is_in_loop() {
         return Err(CompileError::NotInALoop {
-            msg: "'continue' can only be used inside a loop".to_string(),
+            msg: format!("'{keyword}' can only be used inside a loop"),
             span: Some(call.head),
         });
     }
     builder.load_empty(io_reg)?;
-    for _ in 0..builder.context_stack.try_block_depth_from_loop() {
+    for _ in 0..builder.context_stack.error_handler_depth_from_loop() {
         builder.push(Instruction::PopErrorHandler.into_spanned(call.head))?;
     }
-    builder.push_continue(call.head)?;
-    builder.add_comment("continue");
+    let finally_count = builder.context_stack.finally_depth_from_loop();
+    let supersedes = builder.context_stack.crosses_finally_to_loop();
+    builder.push_loop_exit(is_break, finally_count, supersedes, call.head)?;
+    builder.add_comment(keyword);
     Ok(())
 }
 

--- a/crates/nu-engine/src/compile/keyword.rs
+++ b/crates/nu-engine/src/compile/keyword.rs
@@ -716,6 +716,10 @@ pub(crate) fn compile_try(
             }
             .into_spanned(call.head),
         )?;
+        // Marks the end of the `finally` block. On the success path this is a no-op; when a
+        // bail-out (`return`/error/exit) is pending, it resumes that bail-out instead of falling
+        // through into the code after the `try`.
+        builder.push(Instruction::RunFinally.into_spanned(call.head))?;
     }
 
     Ok(())

--- a/crates/nu-engine/src/compile/keyword.rs
+++ b/crates/nu-engine/src/compile/keyword.rs
@@ -547,32 +547,9 @@ pub(crate) fn compile_try(
         })
         .transpose()?;
 
-    // Put the error handler instruction. If we have a catch expression then we should capture the
-    // error.
-    let mut has_try_comment = false;
-    let mut pushed_error_handler = false;
-    if catch_type.is_some() {
-        builder.push(
-            Instruction::OnErrorInto {
-                index: err_label.0,
-                dst: io_reg,
-            }
-            .into_spanned(call.head),
-        )?;
-        builder.add_comment("try");
-        has_try_comment = true;
-        pushed_error_handler = true;
-    } else if finally_expr.is_none() {
-        // Simply try, without `catch` and `finally` block, need to set up OnErrorHandler.
-        // so `try { 1 / 0 }` works
-        builder.push(Instruction::OnError { index: err_label.0 }.into_spanned(call.head))?;
-        builder.add_comment("try");
-        has_try_comment = true;
-        pushed_error_handler = true;
-    };
-
-    builder.begin_try(pushed_error_handler, finally_type.is_some());
-
+    // Set up the handlers. Push the `finally` handler FIRST, then the `catch`, so on the unified
+    // runtime handler stack the `catch` sits above its own `finally`: a body error reaches the
+    // `catch` first, and the `finally` runs afterward on the way out.
     if let Some(finally_info) = &finally_type {
         if finally_info.var_id.is_some() {
             builder.push(
@@ -585,9 +562,32 @@ pub(crate) fn compile_try(
         } else {
             builder.push(Instruction::Finally { index: end_label.0 }.into_spanned(call.head))?;
         }
-        if !has_try_comment {
+        builder.add_comment("try");
+        builder.begin_pending_finally();
+    }
+
+    let mut pushed_error_handler = false;
+    if catch_type.is_some() {
+        builder.push(
+            Instruction::OnErrorInto {
+                index: err_label.0,
+                dst: io_reg,
+            }
+            .into_spanned(call.head),
+        )?;
+        if finally_type.is_none() {
             builder.add_comment("try");
         }
+        pushed_error_handler = true;
+    } else if finally_expr.is_none() {
+        // Simply try, without `catch` and `finally` block, need to set up an error handler,
+        // so `try { 1 / 0 }` works.
+        builder.push(Instruction::OnError { index: err_label.0 }.into_spanned(call.head))?;
+        builder.add_comment("try");
+        pushed_error_handler = true;
+    }
+    if pushed_error_handler {
+        builder.begin_pending_catch();
     }
 
     // Compile the block
@@ -622,9 +622,8 @@ pub(crate) fn compile_try(
 
     if pushed_error_handler {
         builder.push(Instruction::PopErrorHandler.into_spanned(call.head))?;
+        builder.end_pending_catch()?;
     }
-
-    builder.end_try()?;
 
     // Jump over the failure case
     builder.jump(end_label, catch_span)?;
@@ -684,6 +683,7 @@ pub(crate) fn compile_try(
     builder.set_label(end_label, builder.here())?;
     if finally_type.is_some() {
         builder.push(Instruction::PopFinallyRun.into_spanned(call.head))?;
+        builder.end_pending_finally()?;
     }
 
     // This is the finally part.
@@ -701,7 +701,7 @@ pub(crate) fn compile_try(
                 .into_spanned(call.head),
             )?;
         }
-        builder.begin_finally();
+        builder.begin_finally_body();
         compile_block(
             working_set,
             builder,
@@ -710,7 +710,7 @@ pub(crate) fn compile_try(
             Some(io_reg),
             io_reg,
         )?;
-        builder.end_finally()?;
+        builder.end_finally_body()?;
         builder.push(
             Instruction::Move {
                 dst: io_reg,
@@ -1044,8 +1044,9 @@ pub(crate) fn compile_continue(
     compile_loop_exit(builder, call, io_reg, false)
 }
 
-/// Compile a `break` (`is_break`) or `continue`: leave the enclosing loop, first popping the error
-/// handlers and running the `finally` blocks of every `try` block between here and the loop.
+/// Compile a `break` (`is_break`) or `continue`: leave the enclosing loop, unwinding the
+/// `catch`/`finally` handlers of every `try` block between here and the loop (running the finallys,
+/// discarding the catches) via a single `jump-early`.
 fn compile_loop_exit(
     builder: &mut BlockBuilder,
     call: &Call,
@@ -1060,12 +1061,9 @@ fn compile_loop_exit(
         });
     }
     builder.load_empty(io_reg)?;
-    for _ in 0..builder.context_stack.error_handler_depth_from_loop() {
-        builder.push(Instruction::PopErrorHandler.into_spanned(call.head))?;
-    }
-    let finally_count = builder.context_stack.finally_depth_from_loop();
+    let handler_count = builder.context_stack.handler_depth_from_loop();
     let supersedes = builder.context_stack.crosses_finally_to_loop();
-    builder.push_loop_exit(is_break, finally_count, supersedes, call.head)?;
+    builder.push_loop_exit(is_break, handler_count, supersedes, call.head)?;
     builder.add_comment(keyword);
     Ok(())
 }

--- a/crates/nu-engine/src/eval_ir.rs
+++ b/crates/nu-engine/src/eval_ir.rs
@@ -305,6 +305,33 @@ fn eval_ir_block_impl<D: DebugContext>(
                     return Ok(ctx.take_reg(reg_id).with_early_return());
                 }
             }
+            Ok(InstructionResult::PopFinally) => {
+                // On the success path, pop the innermost `finally` handler as usual. While a
+                // bail-out is pending we must not pop: the handler being run was already popped by
+                // the bail-out arm, and the enclosing handlers must survive so `RunFinally` can
+                // resume through them.
+                if ret_val.is_none() {
+                    ctx.stack.finally_run_handlers.pop(ctx.finally_handler_base);
+                }
+                pc += 1;
+            }
+            Ok(InstructionResult::RunFinally) => {
+                // End of an inline `finally`. Nothing to do on the success path. If a bail-out is
+                // pending, resume it: run the next enclosing `finally`, or leave the block with the
+                // pending value once none remain.
+                if ret_val.is_some() {
+                    if let Some(always_run_handler) =
+                        ctx.stack.finally_run_handlers.pop(ctx.finally_handler_base)
+                    {
+                        prepare_error_handler(ctx, always_run_handler, None);
+                        pc = always_run_handler.handler_index;
+                    } else {
+                        return ret_val.take().expect("ret_val was just checked to be Some");
+                    }
+                } else {
+                    pc += 1;
+                }
+            }
             Err(err @ (ShellError::Continue { .. } | ShellError::Break { .. })) => {
                 return Err(err);
             }
@@ -418,6 +445,13 @@ enum InstructionResult {
     /// invocations clear the flag instead, so a `return` in a nested call can't leak out and be
     /// mistaken for a `return` at the current level.
     ReturnEarly(RegId),
+    /// Pop the innermost `finally` handler (the `pop-finally` instruction). While a bail-out is
+    /// pending this is a no-op, so the enclosing handlers survive for the bail-out to resume.
+    PopFinally,
+    /// End of an inline `finally` block (the `run-finally` instruction). On the success path this
+    /// is a no-op; while a bail-out is pending it resumes it, running the next enclosing `finally`
+    /// or leaving the block with the pending value.
+    RunFinally,
 }
 
 /// Perform an instruction
@@ -1085,10 +1119,8 @@ fn eval_instruction<D: DebugContext>(
             ctx.stack.error_handlers.pop(ctx.error_handler_base);
             Ok(Continue)
         }
-        Instruction::PopFinallyRun => {
-            ctx.stack.finally_run_handlers.pop(ctx.finally_handler_base);
-            Ok(Continue)
-        }
+        Instruction::PopFinallyRun => Ok(InstructionResult::PopFinally),
+        Instruction::RunFinally => Ok(InstructionResult::RunFinally),
         Instruction::ReturnEarly { src } => Ok(InstructionResult::ReturnEarly(*src)),
         Instruction::Return { src } => Ok(Return(*src)),
     }

--- a/crates/nu-engine/src/eval_ir.rs
+++ b/crates/nu-engine/src/eval_ir.rs
@@ -242,10 +242,10 @@ fn eval_ir_block_impl<D: DebugContext>(
     // Program counter, starts at zero.
     let mut pc = 0;
     let need_backtrace = ctx.engine_state.get_env_var("NU_BACKTRACE").is_some();
-    // The result of an early exit (`return` or an error) that must still run pending `finally`
-    // handlers before it can leave the block. It takes precedence over the register contents at
-    // the terminal `Return` instruction.
-    let mut ret_val: Option<Result<PipelineExecutionData, ShellError>> = None;
+    // The control-flow exit in flight, if any: a `return`/error/`exit` leaving the block, or a
+    // `break`/`continue` jumping to a loop. It runs pending `finally` blocks first, and takes
+    // precedence over the register contents at the terminal `Return`. See [`Bail`].
+    let mut bail: Option<Bail> = None;
 
     while pc < ir_block.instructions.len() {
         let instruction = &ir_block.instructions[pc];
@@ -272,11 +272,12 @@ fn eval_ir_block_impl<D: DebugContext>(
                 pc = next_pc;
             }
             Ok(InstructionResult::Return(reg_id)) => {
-                // need to check if the return value was stashed by an early `return` or an error
-                // that ran a `finally` handler first. If so, we need to respect that value.
-                match ret_val {
-                    Some(res) => return res,
-                    None => return Ok(ctx.take_reg(reg_id)),
+                // If a `finally` ran on the way out for a pending `return`/error/exit, respect that
+                // stashed value; otherwise return the register. (A `break`/`continue` consumes its
+                // own `bail` at `run-finally` before any terminal `Return`.)
+                match bail.take() {
+                    Some(Bail::Leave(res)) => return res,
+                    _ => return Ok(ctx.take_reg(reg_id)),
                 }
             }
             Ok(InstructionResult::ReturnEarly(reg_id)) => {
@@ -292,9 +293,10 @@ fn eval_ir_block_impl<D: DebugContext>(
                     let collected = collect(data, *span, false);
                     #[cfg(not(feature = "os"))]
                     let collected = collect(data, *span);
-                    ret_val = Some(
-                        collected.map(|body| PipelineExecutionData::from(body).with_early_return()),
-                    );
+                    bail =
+                        Some(Bail::Leave(collected.map(|body| {
+                            PipelineExecutionData::from(body).with_early_return()
+                        })));
                     prepare_error_handler(ctx, always_run_handler, None);
                     pc = always_run_handler.handler_index;
                 } else {
@@ -305,31 +307,79 @@ fn eval_ir_block_impl<D: DebugContext>(
                     return Ok(ctx.take_reg(reg_id).with_early_return());
                 }
             }
+            Ok(InstructionResult::JumpEarly {
+                target,
+                finally_count,
+                supersedes,
+            }) => {
+                // `break`/`continue`. Clear any pending exit whose finally is running. If this jump
+                // leaves that finally (`supersedes`), the exit is discarded; otherwise the jump is
+                // local to a loop nested inside the finally, so keep the exit to restore once the
+                // jump reaches its loop.
+                let saved = bail.take().filter(|_| !supersedes).map(Box::new);
+                let handler = if finally_count > 0 {
+                    ctx.stack.finally_run_handlers.pop(ctx.finally_handler_base)
+                } else {
+                    None
+                };
+                if let Some(handler) = handler {
+                    bail = Some(Bail::Jump {
+                        target,
+                        remaining: finally_count - 1,
+                        saved,
+                    });
+                    prepare_error_handler(ctx, handler, None);
+                    pc = handler.handler_index;
+                } else {
+                    // Nothing more to run (count 0, or the stack was shorter than the compiler
+                    // counted): restore the preserved exit, if any, and jump.
+                    bail = saved.map(|b| *b);
+                    pc = target;
+                }
+            }
             Ok(InstructionResult::PopFinally) => {
                 // On the success path, pop the innermost `finally` handler as usual. While a
                 // bail-out is pending we must not pop: the handler being run was already popped by
                 // the bail-out arm, and the enclosing handlers must survive so `RunFinally` can
                 // resume through them.
-                if ret_val.is_none() {
+                if bail.is_none() {
                     ctx.stack.finally_run_handlers.pop(ctx.finally_handler_base);
                 }
                 pc += 1;
             }
             Ok(InstructionResult::RunFinally) => {
-                // End of an inline `finally`. Nothing to do on the success path. If a bail-out is
-                // pending, resume it: run the next enclosing `finally`, or leave the block with the
-                // pending value once none remain.
-                if ret_val.is_some() {
-                    if let Some(always_run_handler) =
-                        ctx.stack.finally_run_handlers.pop(ctx.finally_handler_base)
-                    {
-                        prepare_error_handler(ctx, always_run_handler, None);
-                        pc = always_run_handler.handler_index;
-                    } else {
-                        return ret_val.take().expect("ret_val was just checked to be Some");
+                // End of an inline `finally`. With no `bail` this is the success path: fall through
+                // to the code after the try. Otherwise decide whether another enclosing `finally`
+                // still needs to run for the pending exit. A `Leave` runs them all the way to the
+                // block base; a `Jump` runs only `remaining` more, stopping at its loop.
+                let run_next = match &mut bail {
+                    None => false,
+                    Some(Bail::Leave(_)) => true,
+                    Some(Bail::Jump { remaining, .. }) => {
+                        let more = *remaining > 0;
+                        if more {
+                            *remaining -= 1;
+                        }
+                        more
                     }
+                };
+                let next_handler = run_next
+                    .then(|| ctx.stack.finally_run_handlers.pop(ctx.finally_handler_base))
+                    .flatten();
+                if let Some(handler) = next_handler {
+                    prepare_error_handler(ctx, handler, None);
+                    pc = handler.handler_index;
                 } else {
-                    pc += 1;
+                    // No more finallys to run: perform the exit's terminal action.
+                    match bail.take() {
+                        None => pc += 1,
+                        Some(Bail::Leave(res)) => return res,
+                        Some(Bail::Jump { target, saved, .. }) => {
+                            // Restore the exit this jump ran inside but did not supersede.
+                            bail = saved.map(|b| *b);
+                            pc = target;
+                        }
+                    }
                 }
             }
             Err(err @ (ShellError::Continue { .. } | ShellError::Break { .. })) => {
@@ -343,7 +393,7 @@ fn eval_ir_block_impl<D: DebugContext>(
                     // and record the exit error firstly.
                     prepare_error_handler(ctx, always_run_handler, None);
                     pc = always_run_handler.handler_index;
-                    ret_val = Some(Err(err));
+                    bail = Some(Bail::Leave(Err(err)));
                 } else {
                     // These block control related errors should be passed through
                     return Err(err);
@@ -379,7 +429,7 @@ fn eval_ir_block_impl<D: DebugContext>(
                         Some(err.clone().into_spanned(*span)),
                     );
                     pc = always_run_handler.handler_index;
-                    ret_val = Some(Err(err));
+                    bail = Some(Bail::Leave(Err(err)));
                 } else if need_backtrace {
                     let err = ShellError::into_chained(err, *span);
                     return Err(err);
@@ -445,6 +495,14 @@ enum InstructionResult {
     /// invocations clear the flag instead, so a `return` in a nested call can't leak out and be
     /// mistaken for a `return` at the current level.
     ReturnEarly(RegId),
+    /// Leave a loop via `break`/`continue` (the `jump-early` instruction): run `finally_count`
+    /// pending `finally` blocks, then jump to `target` (the loop label). If `supersedes`, discard
+    /// any pending return/error whose `finally` is currently running; otherwise keep it.
+    JumpEarly {
+        target: usize,
+        finally_count: usize,
+        supersedes: bool,
+    },
     /// Pop the innermost `finally` handler (the `pop-finally` instruction). While a bail-out is
     /// pending this is a no-op, so the enclosing handlers survive for the bail-out to resume.
     PopFinally,
@@ -453,6 +511,24 @@ enum InstructionResult {
     /// or leaving the block with the pending value. A `return` that leaves this way keeps its
     /// early-return flag, so it still reads as a `return` at the current level.
     RunFinally,
+}
+
+/// A control-flow exit that must run pending `finally` blocks before it takes effect. One shared
+/// slot holds whichever exit is in flight, and [`Instruction::RunFinally`] dispatches on it after
+/// each `finally` runs. `return`, an error, and `exit` all `Leave` the block; `break`/`continue`
+/// `Jump` to a loop label, and take precedence over a `Leave` whose `finally` they run inside.
+enum Bail {
+    /// `return`, an error, or `exit`: run every pending `finally` to the block base, then leave
+    /// the block with this value/error.
+    Leave(Result<PipelineExecutionData, ShellError>),
+    /// `break`/`continue`: run `remaining` more pending `finally` blocks, then jump to `target`.
+    /// `saved` holds a `Leave` this jump ran inside but did not supersede (a break/continue local to
+    /// a loop nested in a finally); it is restored once the jump reaches its loop.
+    Jump {
+        target: usize,
+        remaining: usize,
+        saved: Option<Box<Bail>>,
+    },
 }
 
 /// Perform an instruction
@@ -1123,6 +1199,15 @@ fn eval_instruction<D: DebugContext>(
         Instruction::PopFinallyRun => Ok(InstructionResult::PopFinally),
         Instruction::RunFinally => Ok(InstructionResult::RunFinally),
         Instruction::ReturnEarly { src } => Ok(InstructionResult::ReturnEarly(*src)),
+        Instruction::JumpEarly {
+            index,
+            finally_count,
+            supersedes,
+        } => Ok(InstructionResult::JumpEarly {
+            target: *index,
+            finally_count: *finally_count,
+            supersedes: *supersedes,
+        }),
         Instruction::Return { src } => Ok(Return(*src)),
     }
 }

--- a/crates/nu-engine/src/eval_ir.rs
+++ b/crates/nu-engine/src/eval_ir.rs
@@ -11,7 +11,7 @@ use nu_protocol::{
     combined_type_string,
     debugger::DebugContext,
     engine::{
-        Argument, Closure, EngineState, EnvName, ErrorHandler, Matcher, Redirection, Stack,
+        Argument, Closure, EngineState, EnvName, Handler, HandlerKind, Matcher, Redirection, Stack,
         StateWorkingSet,
     },
     ir::{Call, DataSlice, Instruction, IrAstRef, IrBlock, Literal, RedirectMode},
@@ -66,8 +66,7 @@ pub fn eval_ir_block<D: DebugContext>(
         D::enter_block(engine_state, block);
 
         let args_base = stack.arguments.get_base();
-        let error_handler_base = stack.error_handlers.get_base();
-        let finally_handler_base = stack.finally_run_handlers.get_base();
+        let handler_base = stack.handlers.get_base();
 
         // Allocate and initialize registers. I've found that it's not really worth trying to avoid
         // the heap allocation here by reusing buffers - our allocator is fast enough
@@ -86,8 +85,7 @@ pub fn eval_ir_block<D: DebugContext>(
                 data: &ir_block.data,
                 block_span: &block.span,
                 args_base,
-                error_handler_base,
-                finally_handler_base,
+                handler_base,
                 redirect_out: None,
                 redirect_err: None,
                 matches: vec![],
@@ -98,8 +96,7 @@ pub fn eval_ir_block<D: DebugContext>(
             input,
         );
 
-        stack.error_handlers.leave_frame(error_handler_base);
-        stack.finally_run_handlers.leave_frame(finally_handler_base);
+        stack.handlers.leave_frame(handler_base);
         stack.arguments.leave_frame(args_base);
 
         D::leave_block(engine_state, block);
@@ -138,10 +135,8 @@ struct EvalContext<'a> {
     block_span: &'a Option<Span>,
     /// Base index on the argument stack to reset to after a call
     args_base: usize,
-    /// Base index on the error handler stack to reset to after a call
-    error_handler_base: usize,
-    /// Base index on the finally handler stack to reset to after a call
-    finally_handler_base: usize,
+    /// Base index on the unified `catch`/`finally` handler stack to reset to after a call
+    handler_base: usize,
     /// State set by redirect-out
     redirect_out: Option<Redirection>,
     /// State set by redirect-err
@@ -276,18 +271,17 @@ fn eval_ir_block_impl<D: DebugContext>(
                 // stashed value; otherwise return the register. (A `break`/`continue` consumes its
                 // own `bail` at `run-finally` before any terminal `Return`.)
                 match bail.take() {
-                    Some(Bail::Leave(res)) => return res,
+                    Some(Bail::Leave(result)) => return result,
+                    Some(Bail::Unwind(err)) => return Err(err),
                     _ => return Ok(ctx.take_reg(reg_id)),
                 }
             }
             Ok(InstructionResult::ReturnEarly(reg_id)) => {
-                if let Some(always_run_handler) =
-                    ctx.stack.finally_run_handlers.pop(ctx.finally_handler_base)
-                {
-                    // A `finally` block is pending: collect the value first (mirroring the
-                    // `try-collect` the compiler emits on the fall-through path, which also
-                    // preserves metadata), stash it, and run the `finally` block. The stashed
-                    // value is returned at the terminal `Return` instruction.
+                if ctx.stack.handlers.has_finally(ctx.handler_base) {
+                    // A `finally` is pending: collect the value first (mirroring the `try-collect`
+                    // the compiler emits on the fall-through path, which also preserves metadata),
+                    // stash it as a non-catchable exit, and unwind. The stashed value is returned
+                    // at the terminal `Return` instruction.
                     let data = ctx.take_reg(reg_id);
                     #[cfg(feature = "os")]
                     let collected = collect(data, *span, false);
@@ -297,8 +291,10 @@ fn eval_ir_block_impl<D: DebugContext>(
                         Some(Bail::Leave(collected.map(|body| {
                             PipelineExecutionData::from(body).with_early_return()
                         })));
-                    prepare_error_handler(ctx, always_run_handler, None);
-                    pc = always_run_handler.handler_index;
+                    match advance_leave(ctx, &mut bail, *span) {
+                        Some(next_pc) => pc = next_pc,
+                        None => return take_leave(&mut bail),
+                    }
                 } else {
                     // No `finally` pending: this is the same as a tail return, keeping streams
                     // and metadata intact, except the data is flagged as an early return. The
@@ -309,7 +305,7 @@ fn eval_ir_block_impl<D: DebugContext>(
             }
             Ok(InstructionResult::JumpEarly {
                 target,
-                finally_count,
+                handler_count,
                 supersedes,
             }) => {
                 // `break`/`continue`. Clear any pending exit whose finally is running. If this jump
@@ -317,86 +313,85 @@ fn eval_ir_block_impl<D: DebugContext>(
                 // local to a loop nested inside the finally, so keep the exit to restore once the
                 // jump reaches its loop.
                 let saved = bail.take().filter(|_| !supersedes).map(Box::new);
-                let handler = if finally_count > 0 {
-                    ctx.stack.finally_run_handlers.pop(ctx.finally_handler_base)
-                } else {
-                    None
-                };
-                if let Some(handler) = handler {
-                    bail = Some(Bail::Jump {
-                        target,
-                        remaining: finally_count - 1,
-                        saved,
-                    });
-                    prepare_error_handler(ctx, handler, None);
-                    pc = handler.handler_index;
-                } else {
-                    // Nothing more to run (count 0, or the stack was shorter than the compiler
-                    // counted): restore the preserved exit, if any, and jump.
-                    bail = saved.map(|b| *b);
-                    pc = target;
+                let mut remaining = handler_count;
+                match advance_jump(ctx, &mut remaining) {
+                    Some(next_pc) => {
+                        bail = Some(Bail::Jump {
+                            target,
+                            remaining,
+                            saved,
+                        });
+                        pc = next_pc;
+                    }
+                    None => {
+                        // Nothing to run: restore the preserved exit, if any, and jump.
+                        bail = saved.map(|b| *b);
+                        pc = target;
+                    }
                 }
             }
             Ok(InstructionResult::PopFinally) => {
                 // On the success path, pop the innermost `finally` handler as usual. While a
                 // bail-out is pending we must not pop: the handler being run was already popped by
-                // the bail-out arm, and the enclosing handlers must survive so `RunFinally` can
-                // resume through them.
+                // the unwinding arm, and the enclosing handlers must survive to be walked.
                 if bail.is_none() {
-                    ctx.stack.finally_run_handlers.pop(ctx.finally_handler_base);
+                    let popped = ctx.stack.handlers.pop(ctx.handler_base);
+                    debug_assert!(
+                        matches!(
+                            popped,
+                            None | Some(Handler {
+                                kind: HandlerKind::Finally,
+                                ..
+                            })
+                        ),
+                        "pop-finally popped a non-finally handler: {popped:?}"
+                    );
                 }
                 pc += 1;
             }
-            Ok(InstructionResult::RunFinally) => {
+            Ok(InstructionResult::RunFinally) => match bail.take() {
                 // End of an inline `finally`. With no `bail` this is the success path: fall through
-                // to the code after the try. Otherwise decide whether another enclosing `finally`
-                // still needs to run for the pending exit. A `Leave` runs them all the way to the
-                // block base; a `Jump` runs only `remaining` more, stopping at its loop.
-                let run_next = match &mut bail {
-                    None => false,
-                    Some(Bail::Leave(_)) => true,
-                    Some(Bail::Jump { remaining, .. }) => {
-                        let more = *remaining > 0;
-                        if more {
-                            *remaining -= 1;
-                        }
-                        more
-                    }
-                };
-                let next_handler = run_next
-                    .then(|| ctx.stack.finally_run_handlers.pop(ctx.finally_handler_base))
-                    .flatten();
-                if let Some(handler) = next_handler {
-                    prepare_error_handler(ctx, handler, None);
-                    pc = handler.handler_index;
-                } else {
-                    // No more finallys to run: perform the exit's terminal action.
-                    match bail.take() {
-                        None => pc += 1,
-                        Some(Bail::Leave(res)) => return res,
-                        Some(Bail::Jump { target, saved, .. }) => {
-                            // Restore the exit this jump ran inside but did not supersede.
-                            bail = saved.map(|b| *b);
-                            pc = target;
-                        }
+                // to the code after the try. Otherwise resume the pending exit through the shared
+                // walk: run the next enclosing `finally`, let a `catch` handle a still-unhandled
+                // error, or perform the exit's terminal action.
+                None => pc += 1,
+                Some(leave @ (Bail::Leave(_) | Bail::Unwind(_))) => {
+                    bail = Some(leave);
+                    match advance_leave(ctx, &mut bail, *span) {
+                        Some(next_pc) => pc = next_pc,
+                        None => return take_leave(&mut bail),
                     }
                 }
-            }
+                Some(Bail::Jump {
+                    target,
+                    mut remaining,
+                    saved,
+                }) => match advance_jump(ctx, &mut remaining) {
+                    Some(next_pc) => {
+                        bail = Some(Bail::Jump {
+                            target,
+                            remaining,
+                            saved,
+                        });
+                        pc = next_pc;
+                    }
+                    None => {
+                        // Restore the exit this jump ran inside but did not supersede.
+                        bail = saved.map(|b| *b);
+                        pc = target;
+                    }
+                },
+            },
             Err(err @ (ShellError::Continue { .. } | ShellError::Break { .. })) => {
                 return Err(err);
             }
             Err(err @ ShellError::Exit { abort: false, .. }) => {
-                if let Some(always_run_handler) =
-                    ctx.stack.finally_run_handlers.pop(ctx.finally_handler_base)
-                {
-                    // need to run finally block before exiting.
-                    // and record the exit error firstly.
-                    prepare_error_handler(ctx, always_run_handler, None);
-                    pc = always_run_handler.handler_index;
-                    bail = Some(Bail::Leave(Err(err)));
-                } else {
-                    // These block control related errors should be passed through
-                    return Err(err);
+                // `exit` runs pending `finally` blocks first, but is not catchable: it passes
+                // through `catch` handlers and leaves the block with the exit error.
+                bail = Some(Bail::Leave(Err(err)));
+                match advance_leave(ctx, &mut bail, *span) {
+                    Some(next_pc) => pc = next_pc,
+                    None => return take_leave(&mut bail),
                 }
             }
             Err(err @ ShellError::Exit { abort: true, .. }) => {
@@ -410,31 +405,34 @@ fn eval_ir_block_impl<D: DebugContext>(
 
                 let is_interrupted =
                     matches!(err, ShellError::Interrupted { .. }) || is_terminated_by_signal;
-                if let Some(error_handler) = ctx.stack.error_handlers.pop(ctx.error_handler_base) {
-                    if is_interrupted {
-                        ctx.engine_state.signals().reset();
+
+                // Unwind to the innermost handler. A `catch` handles the error, stopping its
+                // propagation; a `finally` sitting between the error and any enclosing `catch` runs
+                // first (binding the error into its `$err`), then the error keeps unwinding through
+                // `run-finally` until a `catch` handles it or the block base is reached.
+                match ctx.stack.handlers.pop(ctx.handler_base) {
+                    Some(handler) => {
+                        if is_interrupted {
+                            ctx.engine_state.signals().reset();
+                        }
+                        match handler.kind {
+                            HandlerKind::Catch => {
+                                prepare_error_handler(ctx, handler, Some(err.into_spanned(*span)));
+                                pc = handler.handler_index;
+                            }
+                            HandlerKind::Finally => {
+                                prepare_error_handler(
+                                    ctx,
+                                    handler,
+                                    Some(err.clone().into_spanned(*span)),
+                                );
+                                bail = Some(Bail::Unwind(err));
+                                pc = handler.handler_index;
+                            }
+                        }
                     }
-                    // If an error handler is set, branch there
-                    prepare_error_handler(ctx, error_handler, Some(err.into_spanned(*span)));
-                    pc = error_handler.handler_index;
-                } else if let Some(always_run_handler) =
-                    ctx.stack.finally_run_handlers.pop(ctx.finally_handler_base)
-                {
-                    if is_interrupted {
-                        ctx.engine_state.signals().reset();
-                    }
-                    prepare_error_handler(
-                        ctx,
-                        always_run_handler,
-                        Some(err.clone().into_spanned(*span)),
-                    );
-                    pc = always_run_handler.handler_index;
-                    bail = Some(Bail::Leave(Err(err)));
-                } else if need_backtrace {
-                    let err = ShellError::into_chained(err, *span);
-                    return Err(err);
-                } else {
-                    return Err(err);
+                    None if need_backtrace => return Err(ShellError::into_chained(err, *span)),
+                    None => return Err(err),
                 }
             }
         }
@@ -450,10 +448,10 @@ fn eval_ir_block_impl<D: DebugContext>(
     })
 }
 
-/// Prepare the context for an error handler
+/// Load the error (or empty) into a handler's register before entering its `catch`/`finally` body.
 fn prepare_error_handler(
     ctx: &mut EvalContext<'_>,
-    error_handler: ErrorHandler,
+    error_handler: Handler,
     error: Option<Spanned<ShellError>>,
 ) {
     if let Some(reg_id) = error_handler.error_register {
@@ -495,40 +493,112 @@ enum InstructionResult {
     /// invocations clear the flag instead, so a `return` in a nested call can't leak out and be
     /// mistaken for a `return` at the current level.
     ReturnEarly(RegId),
-    /// Leave a loop via `break`/`continue` (the `jump-early` instruction): run `finally_count`
-    /// pending `finally` blocks, then jump to `target` (the loop label). If `supersedes`, discard
-    /// any pending return/error whose `finally` is currently running; otherwise keep it.
+    /// Leave a loop via `break`/`continue` (the `jump-early` instruction): unwind `handler_count`
+    /// pending handlers (running `finally` blocks, discarding `catch` blocks), then jump to
+    /// `target` (the loop label). If `supersedes`, discard any pending return/error whose `finally`
+    /// is currently running; otherwise keep it.
     JumpEarly {
         target: usize,
-        finally_count: usize,
+        handler_count: usize,
         supersedes: bool,
     },
     /// Pop the innermost `finally` handler (the `pop-finally` instruction). While a bail-out is
     /// pending this is a no-op, so the enclosing handlers survive for the bail-out to resume.
     PopFinally,
     /// End of an inline `finally` block (the `run-finally` instruction). On the success path this
-    /// is a no-op; while a bail-out is pending it resumes it, running the next enclosing `finally`
-    /// or leaving the block with the pending value. A `return` that leaves this way keeps its
-    /// early-return flag, so it still reads as a `return` at the current level.
+    /// is a no-op; while a bail-out is pending it resumes it, running the next enclosing `finally`,
+    /// letting a `catch` handle a still-unhandled error, or leaving the block with the pending
+    /// value. A `return` that leaves this way keeps its early-return flag, so it still reads as a
+    /// `return` at the current level.
     RunFinally,
 }
 
 /// A control-flow exit that must run pending `finally` blocks before it takes effect. One shared
-/// slot holds whichever exit is in flight, and [`Instruction::RunFinally`] dispatches on it after
-/// each `finally` runs. `return`, an error, and `exit` all `Leave` the block; `break`/`continue`
-/// `Jump` to a loop label, and take precedence over a `Leave` whose `finally` they run inside.
+/// slot holds whichever exit is in flight, and [`Instruction::RunFinally`] resumes it after each
+/// `finally` runs. `return`/`exit` `Leave` the block and an error `Unwind`s it (the difference is
+/// whether a `catch` can intercept it); `break`/`continue` `Jump` to a loop label, and take
+/// precedence over a `Leave`/`Unwind` whose `finally` they run inside.
 enum Bail {
-    /// `return`, an error, or `exit`: run every pending `finally` to the block base, then leave
-    /// the block with this value/error.
+    /// `return` or `exit`: run every pending `finally` to the block base, then leave the block with
+    /// this result. Passes through `catch` handlers, since a `return`/`exit` is not catchable.
     Leave(Result<PipelineExecutionData, ShellError>),
-    /// `break`/`continue`: run `remaining` more pending `finally` blocks, then jump to `target`.
-    /// `saved` holds a `Leave` this jump ran inside but did not supersede (a break/continue local to
-    /// a loop nested in a finally); it is restored once the jump reaches its loop.
+    /// A runtime error unwinding: run every pending `finally` (binding the error into the first
+    /// one's `$err`), and let an enclosing `catch` intercept it on the way; if none does, propagate
+    /// it out of the block.
+    Unwind(ShellError),
+    /// `break`/`continue`: run `remaining` more pending `finally` blocks (discarding `catch`
+    /// handlers in the way), then jump to `target`. `saved` holds a `Leave`/`Unwind` this jump ran
+    /// inside but did not supersede (a break/continue local to a loop nested in a finally); it is
+    /// restored once the jump reaches its loop.
     Jump {
         target: usize,
         remaining: usize,
         saved: Option<Box<Bail>>,
     },
+}
+
+/// Resume a pending `Leave` exit (return / error / exit) by consuming handlers from the top of the
+/// stack: run the next pending `finally` (entering its body), let a `catch` handle a catchable
+/// error (entering it and clearing `bail`), or discard a `catch` that does not apply. Returns the
+/// instruction to continue at, or `None` when no handler remains and the exit's terminal action
+/// (return the value, or propagate the error) should run.
+fn advance_leave(
+    ctx: &mut EvalContext<'_>,
+    bail: &mut Option<Bail>,
+    fallback_span: Span,
+) -> Option<usize> {
+    loop {
+        let handler = ctx.stack.handlers.pop(ctx.handler_base)?;
+        match handler.kind {
+            HandlerKind::Finally => {
+                // A `finally` reached while an error is still unwinding does not rebind `$err`;
+                // only the first one, entered from the error arm, does.
+                prepare_error_handler(ctx, handler, None);
+                return Some(handler.handler_index);
+            }
+            HandlerKind::Catch => {
+                if matches!(bail, Some(Bail::Unwind(_))) {
+                    let Some(Bail::Unwind(err)) = bail.take() else {
+                        unreachable!("just checked it is an unwinding error")
+                    };
+                    prepare_error_handler(ctx, handler, Some(err.into_spanned(fallback_span)));
+                    return Some(handler.handler_index);
+                }
+                // Not catchable (a `return`/`exit`): discard this catch and keep unwinding.
+            }
+        }
+    }
+}
+
+/// Resume a pending `break`/`continue` (`Jump`) by consuming up to `remaining` more handlers: run
+/// the next pending `finally` (entering its body) and discard any `catch` in the way. Returns the
+/// instruction to continue at when a `finally` is entered, or `None` when the count is exhausted
+/// and control should jump to the loop.
+fn advance_jump(ctx: &mut EvalContext<'_>, remaining: &mut usize) -> Option<usize> {
+    while *remaining > 0 {
+        let Some(handler) = ctx.stack.handlers.pop(ctx.handler_base) else {
+            // Stack shorter than the compiler counted: nothing more to run.
+            *remaining = 0;
+            return None;
+        };
+        *remaining -= 1;
+        if let HandlerKind::Finally = handler.kind {
+            prepare_error_handler(ctx, handler, None);
+            return Some(handler.handler_index);
+        }
+        // A `catch` in the way is discarded; keep unwinding toward the loop.
+    }
+    None
+}
+
+/// Take a pending `Leave`/`Unwind` and return its result, to leave the block. Only called once no
+/// handlers remain, where `bail` is guaranteed to hold one of those.
+fn take_leave(bail: &mut Option<Bail>) -> Result<PipelineExecutionData, ShellError> {
+    match bail.take() {
+        Some(Bail::Leave(result)) => result,
+        Some(Bail::Unwind(err)) => Err(err),
+        _ => unreachable!("take_leave called without a pending Leave/Unwind"),
+    }
 }
 
 /// Perform an instruction
@@ -1165,35 +1235,51 @@ fn eval_instruction<D: DebugContext>(
             end_index,
         } => eval_iterate(ctx, *dst, *stream, *end_index, *span),
         Instruction::OnError { index } => {
-            ctx.stack.error_handlers.push(ErrorHandler {
+            ctx.stack.handlers.push(Handler {
                 handler_index: *index,
                 error_register: None,
+                kind: HandlerKind::Catch,
             });
             Ok(Continue)
         }
         Instruction::OnErrorInto { index, dst } => {
-            ctx.stack.error_handlers.push(ErrorHandler {
+            ctx.stack.handlers.push(Handler {
                 handler_index: *index,
                 error_register: Some(*dst),
+                kind: HandlerKind::Catch,
             });
             Ok(Continue)
         }
         Instruction::Finally { index } => {
-            ctx.stack.finally_run_handlers.push(ErrorHandler {
+            ctx.stack.handlers.push(Handler {
                 handler_index: *index,
                 error_register: None,
+                kind: HandlerKind::Finally,
             });
             Ok(Continue)
         }
         Instruction::FinallyInto { index, dst } => {
-            ctx.stack.finally_run_handlers.push(ErrorHandler {
+            ctx.stack.handlers.push(Handler {
                 handler_index: *index,
                 error_register: Some(*dst),
+                kind: HandlerKind::Finally,
             });
             Ok(Continue)
         }
         Instruction::PopErrorHandler => {
-            ctx.stack.error_handlers.pop(ctx.error_handler_base);
+            // Only reached on the success fall-through, where the top handler is this `try`'s
+            // `catch`; on an error the catch is consumed by the error arm and this is skipped.
+            let popped = ctx.stack.handlers.pop(ctx.handler_base);
+            debug_assert!(
+                matches!(
+                    popped,
+                    None | Some(Handler {
+                        kind: HandlerKind::Catch,
+                        ..
+                    })
+                ),
+                "pop-error-handler popped a non-catch handler: {popped:?}"
+            );
             Ok(Continue)
         }
         Instruction::PopFinallyRun => Ok(InstructionResult::PopFinally),
@@ -1201,11 +1287,11 @@ fn eval_instruction<D: DebugContext>(
         Instruction::ReturnEarly { src } => Ok(InstructionResult::ReturnEarly(*src)),
         Instruction::JumpEarly {
             index,
-            finally_count,
+            handler_count,
             supersedes,
         } => Ok(InstructionResult::JumpEarly {
             target: *index,
-            finally_count: *finally_count,
+            handler_count: *handler_count,
             supersedes: *supersedes,
         }),
         Instruction::Return { src } => Ok(Return(*src)),

--- a/crates/nu-engine/src/eval_ir.rs
+++ b/crates/nu-engine/src/eval_ir.rs
@@ -450,7 +450,8 @@ enum InstructionResult {
     PopFinally,
     /// End of an inline `finally` block (the `run-finally` instruction). On the success path this
     /// is a no-op; while a bail-out is pending it resumes it, running the next enclosing `finally`
-    /// or leaving the block with the pending value.
+    /// or leaving the block with the pending value. A `return` that leaves this way keeps its
+    /// early-return flag, so it still reads as a `return` at the current level.
     RunFinally,
 }
 

--- a/crates/nu-protocol/src/engine/error_handler.rs
+++ b/crates/nu-protocol/src/engine/error_handler.rs
@@ -1,23 +1,41 @@
 use crate::RegId;
 
-/// Describes an error handler stored during IR evaluation.
+/// Whether a [`Handler`] catches an error or always runs when its `try` block is left.
+///
+/// Both live on the same [`HandlerStack`] so their relative nesting order is structural: a
+/// `try`'s `finally` is pushed before its `catch`, so the `catch` sits above and is found first
+/// for an error in the `try` body, while the `finally` runs afterward on the way out. On any exit
+/// (error, `return`, `break`/`continue`, `exit`) the evaluator walks the stack, running the
+/// [`Finally`](HandlerKind::Finally) handlers and handling or discarding the
+/// [`Catch`](HandlerKind::Catch) ones.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum HandlerKind {
+    /// A `catch` block: handles an error escaping the `try` body, stopping its propagation.
+    Catch,
+    /// A `finally` block: runs whenever the `try` is left, then the pending exit continues.
+    Finally,
+}
+
+/// Describes a `catch`/`finally` handler stored during IR evaluation.
 #[derive(Debug, Clone, Copy)]
-pub struct ErrorHandler {
-    /// Instruction index within the block that will handle the error
+pub struct Handler {
+    /// Instruction index within the block that will handle the error or run the `finally`
     pub handler_index: usize,
     /// Register to put the error information into, when an error occurs
     pub error_register: Option<RegId>,
+    /// Whether this handler catches an error or always runs on the way out
+    pub kind: HandlerKind,
 }
 
-/// Keeps track of error handlers pushed during evaluation of an IR block.
+/// Keeps track of the `catch` and `finally` handlers pushed during evaluation of an IR block.
 #[derive(Debug, Clone, Default)]
-pub struct ErrorHandlerStack {
-    handlers: Vec<ErrorHandler>,
+pub struct HandlerStack {
+    handlers: Vec<Handler>,
 }
 
-impl ErrorHandlerStack {
-    pub const fn new() -> ErrorHandlerStack {
-        ErrorHandlerStack { handlers: vec![] }
+impl HandlerStack {
+    pub const fn new() -> HandlerStack {
+        HandlerStack { handlers: vec![] }
     }
 
     /// Get the current base of the stack, which establishes a frame.
@@ -25,14 +43,22 @@ impl ErrorHandlerStack {
         self.handlers.len()
     }
 
-    /// Push a new error handler onto the stack.
-    pub fn push(&mut self, handler: ErrorHandler) {
+    /// Push a new handler onto the stack.
+    pub fn push(&mut self, handler: Handler) {
         self.handlers.push(handler);
     }
 
-    /// Try to pop an error handler from the stack. Won't go below `base`, to avoid retrieving a
+    /// Whether any `finally` handler is pending in the current frame (at or above `base`). Used to
+    /// keep the streaming fast path for a `return` that has no `finally` to run.
+    pub fn has_finally(&self, base: usize) -> bool {
+        self.handlers[base..]
+            .iter()
+            .any(|h| h.kind == HandlerKind::Finally)
+    }
+
+    /// Try to pop a handler from the stack. Won't go below `base`, to avoid retrieving a
     /// handler belonging to a parent frame.
-    pub fn pop(&mut self, base: usize) -> Option<ErrorHandler> {
+    pub fn pop(&mut self, base: usize) -> Option<Handler> {
         if self.handlers.len() > base {
             self.handlers.pop()
         } else {
@@ -47,7 +73,7 @@ impl ErrorHandlerStack {
             self.handlers.truncate(base);
         } else {
             panic!(
-                "ErrorHandlerStack bug: tried to leave frame at {base}, but current base is {}",
+                "HandlerStack bug: tried to leave frame at {base}, but current base is {}",
                 self.get_base()
             )
         }

--- a/crates/nu-protocol/src/engine/stack.rs
+++ b/crates/nu-protocol/src/engine/stack.rs
@@ -2,7 +2,7 @@ use crate::{
     Config, ENV_VARIABLE_ID, IntoValue, NU_VARIABLE_ID, OutDest, ShellError, Span, Value, VarId,
     ast::PathMember,
     engine::{
-        ArgumentStack, DEFAULT_OVERLAY_NAME, EngineState, EnvName, ErrorHandlerStack, Redirection,
+        ArgumentStack, DEFAULT_OVERLAY_NAME, EngineState, EnvName, HandlerStack, Redirection,
         StackCallArgGuard, StackCollectValueGuard, StackIoGuard, StackOutDest,
     },
     report_shell_warning,
@@ -52,10 +52,9 @@ pub struct Stack {
     pub active_overlays: Vec<String>,
     /// Argument stack for IR evaluation
     pub arguments: ArgumentStack,
-    /// Error handler stack for IR evaluation
-    pub error_handlers: ErrorHandlerStack,
-    /// Finally handler stack for IR evaluation
-    pub finally_run_handlers: ErrorHandlerStack,
+    /// Unified `catch`/`finally` handler stack for IR evaluation. Both kinds share one stack so
+    /// their nesting order is structural; the evaluator walks it on every exit. See [`HandlerStack`].
+    pub handlers: HandlerStack,
     pub recursion_count: u64,
     pub parent_stack: Option<Arc<Stack>>,
     /// Variables that have been deleted (this is used to hide values from parent stack lookups)
@@ -92,8 +91,7 @@ impl Stack {
             env_hide_history: Arc::new(HashMap::new()),
             active_overlays: vec![DEFAULT_OVERLAY_NAME.to_string()],
             arguments: ArgumentStack::new(),
-            error_handlers: ErrorHandlerStack::new(),
-            finally_run_handlers: ErrorHandlerStack::new(),
+            handlers: HandlerStack::new(),
             recursion_count: 0,
             parent_stack: None,
             parent_deletions: vec![],
@@ -116,8 +114,7 @@ impl Stack {
             env_hide_history: parent.env_hide_history.clone(),
             active_overlays: parent.active_overlays.clone(),
             arguments: ArgumentStack::new(),
-            error_handlers: ErrorHandlerStack::new(),
-            finally_run_handlers: ErrorHandlerStack::new(),
+            handlers: HandlerStack::new(),
             recursion_count: parent.recursion_count,
             vars: vec![],
             parent_deletions: vec![],
@@ -390,8 +387,7 @@ impl Stack {
             env_hide_history: self.env_hide_history.clone(),
             active_overlays: self.active_overlays.clone(),
             arguments: ArgumentStack::new(),
-            error_handlers: ErrorHandlerStack::new(),
-            finally_run_handlers: ErrorHandlerStack::new(),
+            handlers: HandlerStack::new(),
             recursion_count: self.recursion_count,
             parent_stack: None,
             parent_deletions: vec![],
@@ -427,8 +423,7 @@ impl Stack {
             env_hide_history: self.env_hide_history.clone(),
             active_overlays: self.active_overlays.clone(),
             arguments: ArgumentStack::new(),
-            error_handlers: ErrorHandlerStack::new(),
-            finally_run_handlers: ErrorHandlerStack::new(),
+            handlers: HandlerStack::new(),
             recursion_count: self.recursion_count,
             parent_stack: None,
             parent_deletions: vec![],

--- a/crates/nu-protocol/src/ir/display.rs
+++ b/crates/nu-protocol/src/ir/display.rs
@@ -286,6 +286,17 @@ impl fmt::Display for FmtInstruction<'_> {
             Instruction::ReturnEarly { src } => {
                 write!(f, "{:WIDTH$} {src}", "return-early")
             }
+            Instruction::JumpEarly {
+                index,
+                finally_count,
+                supersedes,
+            } => {
+                write!(
+                    f,
+                    "{:WIDTH$} {index}, finally {finally_count}, supersedes {supersedes}",
+                    "jump-early"
+                )
+            }
             Instruction::Return { src } => {
                 write!(f, "{:WIDTH$} {src}", "return")
             }

--- a/crates/nu-protocol/src/ir/display.rs
+++ b/crates/nu-protocol/src/ir/display.rs
@@ -280,6 +280,9 @@ impl fmt::Display for FmtInstruction<'_> {
             Instruction::PopFinallyRun => {
                 write!(f, "{:WIDTH$}", "pop-finally")
             }
+            Instruction::RunFinally => {
+                write!(f, "{:WIDTH$}", "run-finally")
+            }
             Instruction::ReturnEarly { src } => {
                 write!(f, "{:WIDTH$} {src}", "return-early")
             }

--- a/crates/nu-protocol/src/ir/display.rs
+++ b/crates/nu-protocol/src/ir/display.rs
@@ -288,12 +288,12 @@ impl fmt::Display for FmtInstruction<'_> {
             }
             Instruction::JumpEarly {
                 index,
-                finally_count,
+                handler_count,
                 supersedes,
             } => {
                 write!(
                     f,
-                    "{:WIDTH$} {index}, finally {finally_count}, supersedes {supersedes}",
+                    "{:WIDTH$} {index}, handlers {handler_count}, supersedes {supersedes}",
                     "jump-early"
                 )
             }

--- a/crates/nu-protocol/src/ir/mod.rs
+++ b/crates/nu-protocol/src/ir/mod.rs
@@ -285,14 +285,15 @@ pub enum Instruction {
     /// return. Custom command and closure calls clear that flag; only top-level file evaluation
     /// reads it, to skip `main`.
     ReturnEarly { src: RegId },
-    /// Leave a loop via `break`/`continue`, first running the `finally_count` pending `finally`
-    /// blocks that sit between here and the loop (innermost first), then jumping to `index` (the
-    /// loop's break or continue label). `supersedes` is set when this exit leaves a `finally`, in
-    /// which case it discards a pending `return`/error whose `finally` is currently running; when
-    /// unset (a break/continue local to a loop nested inside a finally) that pending exit is kept.
+    /// Leave a loop via `break`/`continue`, unwinding the `handler_count` `catch`/`finally`
+    /// handlers that sit between here and the loop (innermost first): each pending `finally` runs,
+    /// each `catch` is discarded, then control jumps to `index` (the loop's break or continue
+    /// label). `supersedes` is set when this exit leaves a `finally`, in which case it discards a
+    /// pending `return`/error whose `finally` is currently running; when unset (a break/continue
+    /// local to a loop nested inside a finally) that pending exit is kept.
     JumpEarly {
         index: usize,
-        finally_count: usize,
+        handler_count: usize,
         supersedes: bool,
     },
     /// Return from the block with the value in the register

--- a/crates/nu-protocol/src/ir/mod.rs
+++ b/crates/nu-protocol/src/ir/mod.rs
@@ -285,6 +285,16 @@ pub enum Instruction {
     /// return. Custom command and closure calls clear that flag; only top-level file evaluation
     /// reads it, to skip `main`.
     ReturnEarly { src: RegId },
+    /// Leave a loop via `break`/`continue`, first running the `finally_count` pending `finally`
+    /// blocks that sit between here and the loop (innermost first), then jumping to `index` (the
+    /// loop's break or continue label). `supersedes` is set when this exit leaves a `finally`, in
+    /// which case it discards a pending `return`/error whose `finally` is currently running; when
+    /// unset (a break/continue local to a loop nested inside a finally) that pending exit is kept.
+    JumpEarly {
+        index: usize,
+        finally_count: usize,
+        supersedes: bool,
+    },
     /// Return from the block with the value in the register
     Return { src: RegId },
 }
@@ -364,6 +374,7 @@ impl Instruction {
             Instruction::PopFinallyRun => None,
             Instruction::RunFinally => None,
             Instruction::ReturnEarly { .. } => None,
+            Instruction::JumpEarly { .. } => None,
             Instruction::Return { .. } => None,
         }
     }
@@ -389,6 +400,7 @@ impl Instruction {
             Instruction::OnErrorInto { index, dst: _ } => Some(*index),
             Instruction::Finally { index } => Some(*index),
             Instruction::FinallyInto { index, dst: _ } => Some(*index),
+            Instruction::JumpEarly { index, .. } => Some(*index),
             _ => None,
         }
     }
@@ -416,6 +428,7 @@ impl Instruction {
             Instruction::OnErrorInto { index, dst: _ } => *index = target_index,
             Instruction::Finally { index } => *index = target_index,
             Instruction::FinallyInto { index, dst: _ } => *index = target_index,
+            Instruction::JumpEarly { index, .. } => *index = target_index,
             _ => return Err(target_index),
         }
         Ok(())

--- a/crates/nu-protocol/src/ir/mod.rs
+++ b/crates/nu-protocol/src/ir/mod.rs
@@ -274,6 +274,10 @@ pub enum Instruction {
     PopErrorHandler,
     /// Pop an finally handler.
     PopFinallyRun,
+    /// Marks the end of an inline `finally` block. On the normal (success) path this is a no-op.
+    /// When a bail-out (`return`/error/exit) is pending, it resumes that bail-out: it runs the
+    /// next enclosing `finally`, or leaves the block with the pending value once none remain.
+    RunFinally,
     /// Return early from the block with the value in the register.
     ///
     /// Unlike `return`, this runs pending `finally` handlers first (collecting the value in that
@@ -358,6 +362,7 @@ impl Instruction {
             Instruction::FinallyInto { .. } => None,
             Instruction::PopErrorHandler => None,
             Instruction::PopFinallyRun => None,
+            Instruction::RunFinally => None,
             Instruction::ReturnEarly { .. } => None,
             Instruction::Return { .. } => None,
         }

--- a/tests/eval/mod.rs
+++ b/tests/eval/mod.rs
@@ -546,27 +546,39 @@ fn early_return_in_module_export_env_does_not_abort_caller() -> Result {
 // ===================================================================================
 // Control-flow signals through `finally`: behavior matrix
 //
-// A control-flow signal (`return`, `break`, `continue`) that leaves a block should run any
-// pending `finally` blocks on the way out, and then keep leaving: it must not run the code
-// that sits after the `try`/`finally`, and it must not be swallowed.
+// Markers printed by each case: F = finally ran, I/O = inner/outer finally, C = catch ran,
+// A = code after the try ran, D = code after a loop ran. Trailing letter(s) = the returned
+// value. So "FV" means: finally ran, then the command returned "V".
 //
-// Markers printed by each case: F = finally ran, C = catch ran, A = code-after-the-try ran,
-// I/O = inner/outer finally, D = code after a loop ran. Trailing letter(s) = the value the
-// command returned. So "FV" means: finally ran, then the command returned "V".
+// Group A: a signal in the `try` (return / break / continue) should run any pending `finally`
+// on the way out, then keep leaving. It must not run the code after the try/finally, and it
+// must not be swallowed.
 //
-//   # | case                                   | main (current) | expected | status
-//  ---+----------------------------------------+----------------+----------+--------
-//   1 | return, try/finally, code after        | FAV            | FV       | BUG: `A` runs
-//   2 | return, try/catch/finally, code after  | FAV            | FV       | BUG: `A` runs
-//   3 | return, try/catch, code after          | V              | V        | ok (guard)
-//   4 | return, try/finally, in tail position  | FV             | FV       | ok (guard)
-//   5 | return, nested finally, code after     | IOAV           | IOV      | BUG: `A` runs
-//   6 | break, loop + try/finally              | D              | FD       | BUG: finally skipped
-//   7 | continue, loop + try/finally           | D              | FFD      | BUG: finally skipped
+//   1  return, try/finally, code after           main FAV   want FV    BUG: A runs
+//      def foo [] { try { return "V" } finally { print -n "F" }; print -n "A"; "T" }; foo
+//   2  return, try/catch/finally, code after      main FAV   want FV    BUG: A runs
+//      def foo [] { try { return "V" } catch { print -n "C" } finally { print -n "F" }; print -n "A"; "T" }; foo
+//   3  return, try/catch, code after   (guard)     main V     want V     ok
+//      def foo [] { try { return "V" } catch { print -n "C" }; print -n "A"; "T" }; foo
+//   4  return, try/finally, tail       (guard)     main FV    want FV    ok
+//      def foo [] { try { return "V" } finally { print -n "F" } }; foo
+//   5  return, nested finally, code after          main IOAV  want IOV   BUG: A runs
+//      def foo [] { try { try { return "V" } finally { print -n "I" } } finally { print -n "O" }; print -n "A"; "T" }; foo
+//   6  break, loop + try/finally                   main D     want FD    BUG: finally skipped
+//      for x in [1] { try { break } finally { print -n "F" } }; print -n "D"
+//   7  continue, loop + try/finally                main D     want FFD   BUG: finally skipped
+//      for x in [1 2] { try { continue } finally { print -n "F" } }; print -n "D"
 //
-// The `main (current)` column was confirmed by running each case on the base commit. Cases
-// 1, 2, 5, 6 and 7 are currently wrong; they are marked `#[ignore]` until the finally rework
-// lands, at which point the ignore is removed and the assertion holds.
+// Group B: when the `finally` itself bails out, its own signal overrides whatever the `try`
+// left pending. This already works and is unchanged by the rework; the guards lock it in.
+//
+//   8  finally returns, over a pending return (guard)   want 7
+//      def foo [] { try { return 5 } finally { return 7 } }; foo
+//   9  finally errors, over a pending return  (guard)   want the finally's error
+//      def foo [] { try { return 5 } finally { error make { msg: "from finally" } } }; foo
+//
+// The `main` columns were confirmed by running each case on the base commit. Cases 1, 2, 5, 6
+// and 7 are wrong today and are marked `#[ignore]` until the finally rework lands.
 
 #[test]
 #[ignore = "BUG (matrix #1): `return` through a finally still runs the code after the try"]
@@ -628,6 +640,24 @@ fn finally_runs_on_continue() {
     test_eval(
         r#"for x in [1 2] { try { continue } finally { print -n "F" } }; print -n "D""#,
         Eq("FFD"),
+    )
+}
+
+#[test]
+fn finally_return_overrides_pending_return() {
+    // 8 (guard): a `return` in the finally wins over a `return` pending from the try.
+    test_eval(
+        r#"def foo [] { try { return 5 } finally { return 7 } }; foo"#,
+        Eq("7"),
+    )
+}
+
+#[test]
+fn finally_error_overrides_pending_return() {
+    // 9 (guard): an error in the finally wins over a `return` pending from the try.
+    test_eval(
+        r#"def foo [] { try { return 5 } finally { error make { msg: "from finally" } } }; foo"#,
+        Error("from finally"),
     )
 }
 

--- a/tests/eval/mod.rs
+++ b/tests/eval/mod.rs
@@ -577,11 +577,13 @@ fn early_return_in_module_export_env_does_not_abort_caller() -> Result {
 //   9  finally errors, over a pending return  (guard)   want the finally's error
 //      def foo [] { try { return 5 } finally { error make { msg: "from finally" } } }; foo
 //
-// The `main` columns were confirmed by running each case on the base commit. Cases 1, 2, 5, 6
-// and 7 are wrong today and are marked `#[ignore]` until the finally rework lands.
+// The `main` columns were confirmed by running each case on the base commit. Cases 1, 2 and 5
+// (return through a finally) are fixed by the `run-finally` rework in this change. Cases 6 and 7
+// (break/continue through a finally) are a separate, compiler-level fix and stay `#[ignore]`
+// for a follow-up: unlike `return`, they compile to a direct jump out of the loop, so routing
+// them through a pending finally is a change in `compile/keyword.rs`, not the eval loop.
 
 #[test]
-#[ignore = "BUG (matrix #1): `return` through a finally still runs the code after the try"]
 fn finally_return_skips_code_after() {
     test_eval(
         r#"def foo [] { try { return "V" } finally { print -n "F" }; print -n "A"; "T" }; foo | print"#,
@@ -590,7 +592,6 @@ fn finally_return_skips_code_after() {
 }
 
 #[test]
-#[ignore = "BUG (matrix #2): `return` through catch+finally still runs the code after the try"]
 fn finally_return_with_catch_skips_code_after() {
     test_eval(
         r#"def foo [] { try { return "V" } catch { print -n "C" } finally { print -n "F" }; print -n "A"; "T" }; foo | print"#,
@@ -617,7 +618,6 @@ fn finally_return_in_tail_runs_finally() {
 }
 
 #[test]
-#[ignore = "BUG (matrix #5): `return` through nested finallys still runs the code after the try"]
 fn finally_return_runs_nested_finallys_then_skips_code_after() {
     test_eval(
         r#"def foo [] { try { try { return "V" } finally { print -n "I" } } finally { print -n "O" }; print -n "A"; "T" }; foo | print"#,

--- a/tests/eval/mod.rs
+++ b/tests/eval/mod.rs
@@ -647,7 +647,7 @@ fn finally_runs_on_continue() {
 fn finally_return_overrides_pending_return() {
     // 8 (guard): a `return` in the finally wins over a `return` pending from the try.
     test_eval(
-        r#"def foo [] { try { return 5 } finally { return 7 } }; foo"#,
+        "def foo [] { try { return 5 } finally { return 7 } }; foo",
         Eq("7"),
     )
 }

--- a/tests/eval/mod.rs
+++ b/tests/eval/mod.rs
@@ -446,6 +446,7 @@ fn early_return_keeps_stream() -> Result {
 }
 
 #[test]
+#[serial]
 fn early_return_with_finally_runs_cleanup_and_keeps_value() -> Result {
     // In-process `print` output isn't captured, so the `finally` block reports through the root
     // job's mailbox (`job send 0`) instead. The recovered message and the returned value confirm
@@ -552,162 +553,216 @@ fn early_return_in_module_export_env_does_not_abort_caller() -> Result {
 //
 // How control flow interacts with `finally`.
 //
-// The rule: leaving a `try` runs its `finally` first, then the exit keeps going. The code
-// after the try/finally does not run, and the exit is not lost. Nested finallys run inner
-// first, then outer. If the finally itself exits, its exit replaces whatever the try was doing.
+// The rule: leaving a `try` runs its `finally` first, then the exit keeps going. The code after
+// the try/finally does not run, and the exit is not lost. Nested finallys run inner first, then
+// outer. If the finally itself exits, its exit replaces whatever the try was doing.
 //
-// Trace letters, printed in order: F/I/O a finally ran (I inner, O outer); A the code after
-// the try ran; C a catch ran; D the code after a loop ran. The final letter is the value the
-// function returned.
+// Each case runs in-process via `finally_scenario`. A step of interest announces itself with
+// `"<name>" | job send 0`; the scenario drains those into an ordered `ran` list and reports
+// `{ ran, returned }` (or `{ ran, errored }` when the outcome is an error). So `ran` shows which
+// steps ran and in what order, and `returned` shows the value that came out. Each test's expected
+// record is the source of truth; the list below is a map.
 //
 // A. A signal leaves the try: the finally runs, the signal keeps going, code after is skipped.
-//    1  return, finally, code after                   FV
-//    2  return, catch + finally, code after            FV
-//    3  return, catch, no finally           [guard]     V     (return already skips code after)
-//    4  return, finally, tail               [guard]    FV     (the everyday case)
-//    5  return, nested finallys                        IOV
-//    6  no signal, finally, code after      [guard]    FAT    (the only case where code after runs)
-//    7  break, finally                      [BUG]      FD     (now D: break skips the finally)
-//    8  break, nested finallys              [BUG]      IOD
-//    9  continue, finally                   [BUG]      FFD    (now D: continue skips the finally)
-//   10  continue, nested finallys           [BUG]      IOIOD
+//    1  return, finally, code after
+//    2  return, catch + finally, code after
+//    3  return, catch, no finally                [guard]
+//    4  return, finally, tail                     [guard]
+//    5  return, nested finallys
+//    6  no signal, finally, code after            [guard]  (the only case where code after runs)
+//    7  break, finally                            [BUG]
+//    8  break, nested finallys                    [BUG]
+//    9  continue, finally                         [BUG]
+//   10  continue, nested finallys                 [BUG]
 //
 // B. The finally itself exits: its exit wins over the try's pending exit.
-//   11  finally returns over a pending return          7
-//   12  finally errors  over a pending return          err    (the finally's error, not the return)
-//   13  finally breaks  over a pending return  [BUG]   FDV    (now FDR: the return's value leaks)
-//   14  finally continues over a pending return [BUG]  FFDV   (now FFDR: same leak)
+//   11  finally returns over a pending return
+//   12  finally errors  over a pending return
+//   13  finally breaks  over a pending return     [BUG]
+//   14  finally continues over a pending return   [BUG]
 //
-// An error leaves a try the same way: the finally runs and the error propagates. That is
-// standard try/finally, unchanged here. Group B with a pending break or continue depends on
-// 7-10 and is left out until those work.
+// An error leaves a try the same way: the finally runs and the error propagates. Standard
+// try/finally, unchanged here. Group B with a pending break or continue depends on 7-10 and is
+// left out until those work.
 //
-// This change fixes the return cases: 1, 2 and 5 used to run the code after the try. The break
-// and continue cases (7-10, 13, 14) share one cause: they compile to a direct jump, so they
-// neither run a pending finally nor clear a pending return from inside one. That fix is in
-// `compile/keyword.rs`, left for a follow-up; those cases stay `#[ignore]`.
+// This change fixes the return cases (1, 2, 5): they used to run the code after the try. The
+// [BUG] cases (7-10, 13, 14) share one cause: break and continue compile to a direct jump, so they
+// neither run a pending finally (7-10) nor clear a pending return set from inside one (13, 14).
+// Their assertions state the intended result and stay `#[ignore]` until the fix lands in
+// `compile/keyword.rs`.
 
-#[test]
-fn finally_return_skips_code_after() {
-    test_eval(
-        r#"def foo [] { try { return "V" } finally { print -n "F" }; print -n "A"; "T" }; foo | print"#,
-        Eq("FV"),
-    )
+/// Run a `finally` scenario in-process and return the record it builds. A step in the snippet
+/// announces itself with `"<name>" | job send 0`; the `drain` command (made available here) empties
+/// those from the root job's mailbox into an ordered list, so a scenario ends in, for example,
+/// `{ ran: (drain), returned: $returned }`.
+fn finally_scenario(code: &str) -> Result<Value> {
+    let drain = "def drain [] { mut r = []; loop { let m = (try { job recv --timeout 0sec } catch { break }); $r = ($r | append $m) }; $r }";
+    test().run(format!("{drain}\n{code}"))
 }
 
 #[test]
-fn finally_return_with_catch_skips_code_after() {
-    test_eval(
-        r#"def foo [] { try { return "V" } catch { print -n "C" } finally { print -n "F" }; print -n "A"; "T" }; foo | print"#,
-        Eq("FV"),
+#[serial]
+fn finally_return_skips_code_after() -> Result {
+    finally_scenario(
+        r#"def foo [] { try { return "returned" } finally { "finally" | job send 0 }; "after try" | job send 0; "tail" }
+        let returned = foo
+        { ran: (drain), returned: $returned }"#,
     )
+    .expect_value_eq(test_value!({ ran: ["finally"], returned: "returned" }))
 }
 
 #[test]
-fn return_with_catch_no_finally_skips_code_after() {
+#[serial]
+fn finally_return_with_catch_skips_code_after() -> Result {
+    finally_scenario(
+        r#"def foo [] { try { return "returned" } catch { "catch" | job send 0 } finally { "finally" | job send 0 }; "after try" | job send 0; "tail" }
+        let returned = foo
+        { ran: (drain), returned: $returned }"#,
+    )
+    .expect_value_eq(test_value!({ ran: ["finally"], returned: "returned" }))
+}
+
+#[test]
+#[serial]
+fn return_with_catch_no_finally_skips_code_after() -> Result {
     // guard: without a finally, `return` already skips the code after the try.
-    test_eval(
-        r#"def foo [] { try { return "V" } catch { print -n "C" }; print -n "A"; "T" }; foo | print"#,
-        Eq("V"),
+    finally_scenario(
+        r#"def foo [] { try { return "returned" } catch { "catch" | job send 0 }; "after try" | job send 0; "tail" }
+        let returned = foo
+        { ran: (drain), returned: $returned }"#,
     )
+    .expect_value_eq(test_value!({ ran: [], returned: "returned" }))
 }
 
 #[test]
-fn finally_return_in_tail_runs_finally() {
-    // guard: the common case, `return` last in the body, keeps working.
-    test_eval(
-        r#"def foo [] { try { return "V" } finally { print -n "F" } }; foo | print"#,
-        Eq("FV"),
+#[serial]
+fn finally_return_in_tail_runs_finally() -> Result {
+    // guard: the everyday case, `return` last in the body, keeps working.
+    finally_scenario(
+        r#"def foo [] { try { return "returned" } finally { "finally" | job send 0 } }
+        let returned = foo
+        { ran: (drain), returned: $returned }"#,
     )
+    .expect_value_eq(test_value!({ ran: ["finally"], returned: "returned" }))
 }
 
 #[test]
-fn finally_return_runs_nested_finallys_then_skips_code_after() {
-    test_eval(
-        r#"def foo [] { try { try { return "V" } finally { print -n "I" } } finally { print -n "O" }; print -n "A"; "T" }; foo | print"#,
-        Eq("IOV"),
+#[serial]
+fn finally_return_runs_nested_finallys_then_skips_code_after() -> Result {
+    finally_scenario(
+        r#"def foo [] { try { try { return "returned" } finally { "inner" | job send 0 } } finally { "outer" | job send 0 }; "after try" | job send 0; "tail" }
+        let returned = foo
+        { ran: (drain), returned: $returned }"#,
     )
+    .expect_value_eq(test_value!({ ran: ["inner", "outer"], returned: "returned" }))
 }
 
 #[test]
-fn finally_and_code_after_both_run_on_success() {
+#[serial]
+fn finally_and_code_after_both_run_on_success() -> Result {
     // 6 (guard): with nothing leaving the try, the finally runs and the code after runs too.
-    test_eval(
-        r#"def foo [] { try { "V" } finally { print -n "F" }; print -n "A"; "T" }; foo | print"#,
-        Eq("FAT"),
+    finally_scenario(
+        r#"def foo [] { try { "body" } finally { "finally" | job send 0 }; "after try" | job send 0; "tail" }
+        let returned = foo
+        { ran: (drain), returned: $returned }"#,
     )
+    .expect_value_eq(test_value!({ ran: ["finally", "after try"], returned: "tail" }))
 }
 
 #[test]
 #[ignore = "BUG (matrix 7): `break` skips a pending finally"]
-fn finally_runs_on_break() {
-    test_eval(
-        r#"for x in [1] { try { break } finally { print -n "F" } }; print -n "D""#,
-        Eq("FD"),
+#[serial]
+fn finally_runs_on_break() -> Result {
+    finally_scenario(
+        r#"for x in [1] { try { break } finally { "finally" | job send 0 } }
+        "after loop" | job send 0
+        { ran: (drain) }"#,
     )
+    .expect_value_eq(test_value!({ ran: ["finally", "after loop"] }))
 }
 
 #[test]
 #[ignore = "BUG (matrix 8): `break` skips nested finallys too"]
-fn finally_runs_on_break_nested() {
-    test_eval(
-        r#"for x in [1] { try { try { break } finally { print -n "I" } } finally { print -n "O" } }; print -n "D""#,
-        Eq("IOD"),
+#[serial]
+fn finally_runs_on_break_nested() -> Result {
+    finally_scenario(
+        r#"for x in [1] { try { try { break } finally { "inner" | job send 0 } } finally { "outer" | job send 0 } }
+        "after loop" | job send 0
+        { ran: (drain) }"#,
     )
+    .expect_value_eq(test_value!({ ran: ["inner", "outer", "after loop"] }))
 }
 
 #[test]
 #[ignore = "BUG (matrix 9): `continue` skips a pending finally"]
-fn finally_runs_on_continue() {
-    test_eval(
-        r#"for x in [1 2] { try { continue } finally { print -n "F" } }; print -n "D""#,
-        Eq("FFD"),
+#[serial]
+fn finally_runs_on_continue() -> Result {
+    finally_scenario(
+        r#"for x in [1 2] { try { continue } finally { "finally" | job send 0 } }
+        "after loop" | job send 0
+        { ran: (drain) }"#,
     )
+    .expect_value_eq(test_value!({ ran: ["finally", "finally", "after loop"] }))
 }
 
 #[test]
 #[ignore = "BUG (matrix 10): `continue` skips nested finallys too"]
-fn finally_runs_on_continue_nested() {
-    test_eval(
-        r#"for x in [1 2] { try { try { continue } finally { print -n "I" } } finally { print -n "O" } }; print -n "D""#,
-        Eq("IOIOD"),
+#[serial]
+fn finally_runs_on_continue_nested() -> Result {
+    finally_scenario(
+        r#"for x in [1 2] { try { try { continue } finally { "inner" | job send 0 } } finally { "outer" | job send 0 } }
+        "after loop" | job send 0
+        { ran: (drain) }"#,
     )
+    .expect_value_eq(test_value!({ ran: ["inner", "outer", "inner", "outer", "after loop"] }))
 }
 
 #[test]
-fn finally_return_overrides_pending_return() {
+#[serial]
+fn finally_return_overrides_pending_return() -> Result {
     // 11 (guard): a `return` in the finally wins over a `return` pending from the try.
-    test_eval(
-        "def foo [] { try { return 5 } finally { return 7 } }; foo",
-        Eq("7"),
+    finally_scenario(
+        r#"def foo [] { try { return 5 } finally { "finally" | job send 0; return 7 } }
+        let returned = foo
+        { ran: (drain), returned: $returned }"#,
     )
+    .expect_value_eq(test_value!({ ran: ["finally"], returned: 7 }))
 }
 
 #[test]
-fn finally_error_overrides_pending_return() {
+#[serial]
+fn finally_error_overrides_pending_return() -> Result {
     // 12 (guard): an error in the finally wins over a `return` pending from the try.
-    test_eval(
-        r#"def foo [] { try { return 5 } finally { error make { msg: "from finally" } } }; foo"#,
-        Error("from finally"),
+    finally_scenario(
+        r#"def foo [] { try { return 5 } finally { "finally" | job send 0; error make { msg: "from finally" } } }
+        let errored = (try { foo; null } catch { |e| $e.msg })
+        { ran: (drain), errored: $errored }"#,
     )
+    .expect_value_eq(test_value!({ ran: ["finally"], errored: "from finally" }))
 }
 
 #[test]
-#[ignore = "BUG (matrix 13): `break` in a finally exits the loop but leaks the try's pending return (FDR, want FDV)"]
-fn finally_break_overrides_pending_return() {
-    test_eval(
-        r#"def foo [] { for x in [1 2] { try { return "R" } finally { print -n "F"; break } }; print -n "D"; "V" }; foo | print"#,
-        Eq("FDV"),
+#[ignore = "BUG (matrix 13): `break` in a finally exits the loop but leaks the try's pending return"]
+#[serial]
+fn finally_break_overrides_pending_return() -> Result {
+    finally_scenario(
+        r#"def foo [] { for x in [1 2] { try { return "returned" } finally { "finally" | job send 0; break } }; "after loop" | job send 0; "tail" }
+        let returned = foo
+        { ran: (drain), returned: $returned }"#,
     )
+    .expect_value_eq(test_value!({ ran: ["finally", "after loop"], returned: "tail" }))
 }
 
 #[test]
-#[ignore = "BUG (matrix 14): `continue` in a finally leaks the try's pending return (FFDR, want FFDV)"]
-fn finally_continue_overrides_pending_return() {
-    test_eval(
-        r#"def foo [] { for x in [1 2] { try { return "R" } finally { print -n "F"; continue } }; print -n "D"; "V" }; foo | print"#,
-        Eq("FFDV"),
+#[ignore = "BUG (matrix 14): `continue` in a finally leaks the try's pending return"]
+#[serial]
+fn finally_continue_overrides_pending_return() -> Result {
+    finally_scenario(
+        r#"def foo [] { for x in [1 2] { try { return "returned" } finally { "finally" | job send 0; continue } }; "after loop" | job send 0; "tail" }
+        let returned = foo
+        { ran: (drain), returned: $returned }"#,
     )
+    .expect_value_eq(test_value!({ ran: ["finally", "finally", "after loop"], returned: "tail" }))
 }
 
 #[test]

--- a/tests/eval/mod.rs
+++ b/tests/eval/mod.rs
@@ -581,14 +581,16 @@ fn early_return_in_module_export_env_does_not_abort_caller() -> Result {
 //   13  finally breaks  over a pending return
 //   14  finally continues over a pending return
 //
-// An error leaves a try the same way: the finally runs and the error propagates.
+// An error leaves a try the same way: the finally runs and the error propagates (and an enclosing
+// `catch` may intercept it after the inner finallys run; see the enclosing-catch tests below).
 //
-// All of these hold. `return`, an error, and `exit` run their finallys via the
-// `return-early`/`run-finally` chain in the eval loop; `break`/`continue` join the same chain via
-// `jump-early` (compile/keyword.rs, eval_ir.rs), running the finallys between them and their loop
-// then jumping. A `break`/`continue` that leaves a finally supersedes a pending return (13, 14
-// return the tail, not the leaked value). One that stays inside the finally, targeting a loop
-// nested in it, is local and keeps the pending return instead (see the local_*_in_finally tests).
+// All of these hold. Every exit walks one unified `catch`/`finally` handler stack in nesting order
+// (eval_ir.rs): `return`/error/`exit` unwind to the block base via the `run-finally` chain, and
+// `break`/`continue` unwind to their loop via `jump-early` (compile/keyword.rs), running each
+// pending finally and discarding each catch in the way. A `break`/`continue` that leaves a finally
+// supersedes a pending return (13, 14 return the tail, not the leaked value). One that stays inside
+// the finally, targeting a loop nested in it, is local and keeps the pending return instead (see
+// the local_*_in_finally tests).
 
 /// Run a `finally` scenario in-process and return the record it builds. A step in the snippet
 /// announces itself with `"<name>" | job send 0`; the `drain` command (made available here) empties
@@ -789,6 +791,65 @@ fn local_continue_in_finally_keeps_pending_return() -> Result {
         { ran: (drain), returned: $returned }"#,
     )
     .expect_value_eq(test_value!({ ran: ["finally"], returned: "returned" }))
+}
+
+// An error that is caught by an *enclosing* `catch` must still run the `finally` of every inner
+// `try` it unwinds past, in order, before the catch handles it. These cases were wrong before the
+// `catch`/`finally` handler stacks were unified into one walked in nesting order: the enclosing
+// catch was consulted before the inner finally, so the inner finally was skipped.
+
+#[test]
+#[serial]
+fn error_runs_inner_finally_before_outer_catch() -> Result {
+    finally_scenario(
+        r#"let returned = (try { try { error make { msg: "a" } } finally { "finally" | job send 0 } } catch { |e| $e.msg })
+        { ran: (drain), returned: $returned }"#,
+    )
+    .expect_value_eq(test_value!({ ran: ["finally"], returned: "a" }))
+}
+
+#[test]
+#[serial]
+fn catch_that_throws_runs_inner_finally_before_outer_catch() -> Result {
+    // The inner `catch` throws while an outer `catch` is waiting: the inner `finally` must run
+    // before the outer catch, and the outer catch sees the catch's error.
+    finally_scenario(
+        r#"let returned = (try { try { error make { msg: "a" } } catch { "catch" | job send 0; error make { msg: "b" } } finally { "finally" | job send 0 } } catch { |e| $e.msg })
+        { ran: (drain), returned: $returned }"#,
+    )
+    .expect_value_eq(test_value!({ ran: ["catch", "finally"], returned: "b" }))
+}
+
+#[test]
+#[serial]
+fn error_runs_nested_finallys_before_outer_catch() -> Result {
+    finally_scenario(
+        r#"let returned = (try { try { try { error make { msg: "a" } } finally { "f1" | job send 0 } } finally { "f2" | job send 0 } } catch { |e| $e.msg })
+        { ran: (drain), returned: $returned }"#,
+    )
+    .expect_value_eq(test_value!({ ran: ["f1", "f2"], returned: "a" }))
+}
+
+#[test]
+#[serial]
+fn catch_that_throws_runs_nested_finallys_before_outer_catch() -> Result {
+    finally_scenario(
+        r#"let returned = (try { try { try { error make { msg: "a" } } catch { "c1" | job send 0; error make { msg: "b" } } finally { "f1" | job send 0 } } finally { "f2" | job send 0 } } catch { |e| $e.msg })
+        { ran: (drain), returned: $returned }"#,
+    )
+    .expect_value_eq(test_value!({ ran: ["c1", "f1", "f2"], returned: "b" }))
+}
+
+#[test]
+#[serial]
+fn break_in_catch_runs_finally() -> Result {
+    // A `break` from inside a `catch` still leaves through that `try`'s `finally`.
+    finally_scenario(
+        r#"for x in [1] { try { error make { msg: "a" } } catch { "catch" | job send 0; break } finally { "finally" | job send 0 } }
+        "after loop" | job send 0
+        { ran: (drain) }"#,
+    )
+    .expect_value_eq(test_value!({ ran: ["catch", "finally", "after loop"] }))
 }
 
 #[test]

--- a/tests/eval/mod.rs
+++ b/tests/eval/mod.rs
@@ -570,26 +570,25 @@ fn early_return_in_module_export_env_does_not_abort_caller() -> Result {
 //    4  return, finally, tail                     [guard]
 //    5  return, nested finallys
 //    6  no signal, finally, code after            [guard]  (the only case where code after runs)
-//    7  break, finally                            [BUG]
-//    8  break, nested finallys                    [BUG]
-//    9  continue, finally                         [BUG]
-//   10  continue, nested finallys                 [BUG]
+//    7  break, finally
+//    8  break, nested finallys
+//    9  continue, finally
+//   10  continue, nested finallys
 //
 // B. The finally itself exits: its exit wins over the try's pending exit.
 //   11  finally returns over a pending return
 //   12  finally errors  over a pending return
-//   13  finally breaks  over a pending return     [BUG]
-//   14  finally continues over a pending return   [BUG]
+//   13  finally breaks  over a pending return
+//   14  finally continues over a pending return
 //
-// An error leaves a try the same way: the finally runs and the error propagates. Standard
-// try/finally, unchanged here. Group B with a pending break or continue depends on 7-10 and is
-// left out until those work.
+// An error leaves a try the same way: the finally runs and the error propagates.
 //
-// This change fixes the return cases (1, 2, 5): they used to run the code after the try. The
-// [BUG] cases (7-10, 13, 14) share one cause: break and continue compile to a direct jump, so they
-// neither run a pending finally (7-10) nor clear a pending return set from inside one (13, 14).
-// Their assertions state the intended result and stay `#[ignore]` until the fix lands in
-// `compile/keyword.rs`.
+// All of these hold. `return`, an error, and `exit` run their finallys via the
+// `return-early`/`run-finally` chain in the eval loop; `break`/`continue` join the same chain via
+// `jump-early` (compile/keyword.rs, eval_ir.rs), running the finallys between them and their loop
+// then jumping. A `break`/`continue` that leaves a finally supersedes a pending return (13, 14
+// return the tail, not the leaked value). One that stays inside the finally, targeting a loop
+// nested in it, is local and keeps the pending return instead (see the local_*_in_finally tests).
 
 /// Run a `finally` scenario in-process and return the record it builds. A step in the snippet
 /// announces itself with `"<name>" | job send 0`; the `drain` command (made available here) empties
@@ -670,7 +669,6 @@ fn finally_and_code_after_both_run_on_success() -> Result {
 }
 
 #[test]
-#[ignore = "BUG (matrix 7): `break` skips a pending finally"]
 #[serial]
 fn finally_runs_on_break() -> Result {
     finally_scenario(
@@ -682,7 +680,6 @@ fn finally_runs_on_break() -> Result {
 }
 
 #[test]
-#[ignore = "BUG (matrix 8): `break` skips nested finallys too"]
 #[serial]
 fn finally_runs_on_break_nested() -> Result {
     finally_scenario(
@@ -694,7 +691,6 @@ fn finally_runs_on_break_nested() -> Result {
 }
 
 #[test]
-#[ignore = "BUG (matrix 9): `continue` skips a pending finally"]
 #[serial]
 fn finally_runs_on_continue() -> Result {
     finally_scenario(
@@ -706,7 +702,6 @@ fn finally_runs_on_continue() -> Result {
 }
 
 #[test]
-#[ignore = "BUG (matrix 10): `continue` skips nested finallys too"]
 #[serial]
 fn finally_runs_on_continue_nested() -> Result {
     finally_scenario(
@@ -742,7 +737,6 @@ fn finally_error_overrides_pending_return() -> Result {
 }
 
 #[test]
-#[ignore = "BUG (matrix 13): `break` in a finally exits the loop but leaks the try's pending return"]
 #[serial]
 fn finally_break_overrides_pending_return() -> Result {
     finally_scenario(
@@ -754,7 +748,6 @@ fn finally_break_overrides_pending_return() -> Result {
 }
 
 #[test]
-#[ignore = "BUG (matrix 14): `continue` in a finally leaks the try's pending return"]
 #[serial]
 fn finally_continue_overrides_pending_return() -> Result {
     finally_scenario(
@@ -763,6 +756,39 @@ fn finally_continue_overrides_pending_return() -> Result {
         { ran: (drain), returned: $returned }"#,
     )
     .expect_value_eq(test_value!({ ran: ["finally", "finally", "after loop"], returned: "tail" }))
+}
+
+// A `break`/`continue` that stays inside the finally (it targets a loop nested in the finally, not
+// an enclosing one) is local: it does not supersede the pending return, which resumes once the
+// finally completes. Contrast 13/14, where the break/continue leaves the finally and wins.
+#[test]
+#[serial]
+fn local_break_in_finally_keeps_pending_return() -> Result {
+    finally_scenario(
+        r#"def foo [] {
+            try { return "returned" } finally { for y in [1] { break }; "finally" | job send 0 }
+            "after try" | job send 0
+            "tail"
+        }
+        let returned = foo
+        { ran: (drain), returned: $returned }"#,
+    )
+    .expect_value_eq(test_value!({ ran: ["finally"], returned: "returned" }))
+}
+
+#[test]
+#[serial]
+fn local_continue_in_finally_keeps_pending_return() -> Result {
+    finally_scenario(
+        r#"def foo [] {
+            try { return "returned" } finally { for y in [1 2] { continue }; "finally" | job send 0 }
+            "after try" | job send 0
+            "tail"
+        }
+        let returned = foo
+        { ran: (drain), returned: $returned }"#,
+    )
+    .expect_value_eq(test_value!({ ran: ["finally"], returned: "returned" }))
 }
 
 #[test]

--- a/tests/eval/mod.rs
+++ b/tests/eval/mod.rs
@@ -543,6 +543,94 @@ fn early_return_in_module_export_env_does_not_abort_caller() -> Result {
     )
 }
 
+// ===================================================================================
+// Control-flow signals through `finally`: behavior matrix
+//
+// A control-flow signal (`return`, `break`, `continue`) that leaves a block should run any
+// pending `finally` blocks on the way out, and then keep leaving: it must not run the code
+// that sits after the `try`/`finally`, and it must not be swallowed.
+//
+// Markers printed by each case: F = finally ran, C = catch ran, A = code-after-the-try ran,
+// I/O = inner/outer finally, D = code after a loop ran. Trailing letter(s) = the value the
+// command returned. So "FV" means: finally ran, then the command returned "V".
+//
+//   # | case                                   | main (current) | expected | status
+//  ---+----------------------------------------+----------------+----------+--------
+//   1 | return, try/finally, code after        | FAV            | FV       | BUG: `A` runs
+//   2 | return, try/catch/finally, code after  | FAV            | FV       | BUG: `A` runs
+//   3 | return, try/catch, code after          | V              | V        | ok (guard)
+//   4 | return, try/finally, in tail position  | FV             | FV       | ok (guard)
+//   5 | return, nested finally, code after     | IOAV           | IOV      | BUG: `A` runs
+//   6 | break, loop + try/finally              | D              | FD       | BUG: finally skipped
+//   7 | continue, loop + try/finally           | D              | FFD      | BUG: finally skipped
+//
+// The `main (current)` column was confirmed by running each case on the base commit. Cases
+// 1, 2, 5, 6 and 7 are currently wrong; they are marked `#[ignore]` until the finally rework
+// lands, at which point the ignore is removed and the assertion holds.
+
+#[test]
+#[ignore = "BUG (matrix #1): `return` through a finally still runs the code after the try"]
+fn finally_return_skips_code_after() {
+    test_eval(
+        r#"def foo [] { try { return "V" } finally { print -n "F" }; print -n "A"; "T" }; foo | print"#,
+        Eq("FV"),
+    )
+}
+
+#[test]
+#[ignore = "BUG (matrix #2): `return` through catch+finally still runs the code after the try"]
+fn finally_return_with_catch_skips_code_after() {
+    test_eval(
+        r#"def foo [] { try { return "V" } catch { print -n "C" } finally { print -n "F" }; print -n "A"; "T" }; foo | print"#,
+        Eq("FV"),
+    )
+}
+
+#[test]
+fn return_with_catch_no_finally_skips_code_after() {
+    // guard: without a finally, `return` already skips the code after the try.
+    test_eval(
+        r#"def foo [] { try { return "V" } catch { print -n "C" }; print -n "A"; "T" }; foo | print"#,
+        Eq("V"),
+    )
+}
+
+#[test]
+fn finally_return_in_tail_runs_finally() {
+    // guard: the common case, `return` last in the body, keeps working.
+    test_eval(
+        r#"def foo [] { try { return "V" } finally { print -n "F" } }; foo | print"#,
+        Eq("FV"),
+    )
+}
+
+#[test]
+#[ignore = "BUG (matrix #5): `return` through nested finallys still runs the code after the try"]
+fn finally_return_runs_nested_finallys_then_skips_code_after() {
+    test_eval(
+        r#"def foo [] { try { try { return "V" } finally { print -n "I" } } finally { print -n "O" }; print -n "A"; "T" }; foo | print"#,
+        Eq("IOV"),
+    )
+}
+
+#[test]
+#[ignore = "BUG (matrix #6): `break` skips a pending finally"]
+fn finally_runs_on_break() {
+    test_eval(
+        r#"for x in [1] { try { break } finally { print -n "F" } }; print -n "D""#,
+        Eq("FD"),
+    )
+}
+
+#[test]
+#[ignore = "BUG (matrix #7): `continue` skips a pending finally"]
+fn finally_runs_on_continue() {
+    test_eval(
+        r#"for x in [1 2] { try { continue } finally { print -n "F" } }; print -n "D""#,
+        Eq("FFD"),
+    )
+}
+
 #[test]
 fn try_no_catch() {
     test_eval("try { error make { msg: foo } }; 'pass'", Eq("pass"))

--- a/tests/eval/mod.rs
+++ b/tests/eval/mod.rs
@@ -550,38 +550,42 @@ fn early_return_in_module_export_env_does_not_abort_caller() -> Result {
 // A = code after the try ran, D = code after a loop ran. Trailing letter(s) = the returned
 // value. So "FV" means: finally ran, then the command returned "V".
 //
-// Group A: a signal in the `try` (return / break / continue) should run any pending `finally`
-// on the way out, then keep leaving. It must not run the code after the try/finally, and it
-// must not be swallowed.
+// How control flow interacts with `finally`.
 //
-//   1  return, try/finally, code after           main FAV   want FV    BUG: A runs
-//      def foo [] { try { return "V" } finally { print -n "F" }; print -n "A"; "T" }; foo
-//   2  return, try/catch/finally, code after      main FAV   want FV    BUG: A runs
-//      def foo [] { try { return "V" } catch { print -n "C" } finally { print -n "F" }; print -n "A"; "T" }; foo
-//   3  return, try/catch, code after   (guard)     main V     want V     ok
-//      def foo [] { try { return "V" } catch { print -n "C" }; print -n "A"; "T" }; foo
-//   4  return, try/finally, tail       (guard)     main FV    want FV    ok
-//      def foo [] { try { return "V" } finally { print -n "F" } }; foo
-//   5  return, nested finally, code after          main IOAV  want IOV   BUG: A runs
-//      def foo [] { try { try { return "V" } finally { print -n "I" } } finally { print -n "O" }; print -n "A"; "T" }; foo
-//   6  break, loop + try/finally                   main D     want FD    BUG: finally skipped
-//      for x in [1] { try { break } finally { print -n "F" } }; print -n "D"
-//   7  continue, loop + try/finally                main D     want FFD   BUG: finally skipped
-//      for x in [1 2] { try { continue } finally { print -n "F" } }; print -n "D"
+// The rule: leaving a `try` runs its `finally` first, then the exit keeps going. The code
+// after the try/finally does not run, and the exit is not lost. Nested finallys run inner
+// first, then outer. If the finally itself exits, its exit replaces whatever the try was doing.
 //
-// Group B: when the `finally` itself bails out, its own signal overrides whatever the `try`
-// left pending. This already works and is unchanged by the rework; the guards lock it in.
+// Trace letters, printed in order: F/I/O a finally ran (I inner, O outer); A the code after
+// the try ran; C a catch ran; D the code after a loop ran. The final letter is the value the
+// function returned.
 //
-//   8  finally returns, over a pending return (guard)   want 7
-//      def foo [] { try { return 5 } finally { return 7 } }; foo
-//   9  finally errors, over a pending return  (guard)   want the finally's error
-//      def foo [] { try { return 5 } finally { error make { msg: "from finally" } } }; foo
+// A. A signal leaves the try: the finally runs, the signal keeps going, code after is skipped.
+//    1  return, finally, code after                   FV
+//    2  return, catch + finally, code after            FV
+//    3  return, catch, no finally           [guard]     V     (return already skips code after)
+//    4  return, finally, tail               [guard]    FV     (the everyday case)
+//    5  return, nested finallys                        IOV
+//    6  no signal, finally, code after      [guard]    FAT    (the only case where code after runs)
+//    7  break, finally                      [BUG]      FD     (now D: break skips the finally)
+//    8  break, nested finallys              [BUG]      IOD
+//    9  continue, finally                   [BUG]      FFD    (now D: continue skips the finally)
+//   10  continue, nested finallys           [BUG]      IOIOD
 //
-// The `main` columns were confirmed by running each case on the base commit. Cases 1, 2 and 5
-// (return through a finally) are fixed by the `run-finally` rework in this change. Cases 6 and 7
-// (break/continue through a finally) are a separate, compiler-level fix and stay `#[ignore]`
-// for a follow-up: unlike `return`, they compile to a direct jump out of the loop, so routing
-// them through a pending finally is a change in `compile/keyword.rs`, not the eval loop.
+// B. The finally itself exits: its exit wins over the try's pending exit.
+//   11  finally returns over a pending return          7
+//   12  finally errors  over a pending return          err    (the finally's error, not the return)
+//   13  finally breaks  over a pending return  [BUG]   FDV    (now FDR: the return's value leaks)
+//   14  finally continues over a pending return [BUG]  FFDV   (now FFDR: same leak)
+//
+// An error leaves a try the same way: the finally runs and the error propagates. That is
+// standard try/finally, unchanged here. Group B with a pending break or continue depends on
+// 7-10 and is left out until those work.
+//
+// This change fixes the return cases: 1, 2 and 5 used to run the code after the try. The break
+// and continue cases (7-10, 13, 14) share one cause: they compile to a direct jump, so they
+// neither run a pending finally nor clear a pending return from inside one. That fix is in
+// `compile/keyword.rs`, left for a follow-up; those cases stay `#[ignore]`.
 
 #[test]
 fn finally_return_skips_code_after() {
@@ -626,7 +630,16 @@ fn finally_return_runs_nested_finallys_then_skips_code_after() {
 }
 
 #[test]
-#[ignore = "BUG (matrix #6): `break` skips a pending finally"]
+fn finally_and_code_after_both_run_on_success() {
+    // 6 (guard): with nothing leaving the try, the finally runs and the code after runs too.
+    test_eval(
+        r#"def foo [] { try { "V" } finally { print -n "F" }; print -n "A"; "T" }; foo | print"#,
+        Eq("FAT"),
+    )
+}
+
+#[test]
+#[ignore = "BUG (matrix 7): `break` skips a pending finally"]
 fn finally_runs_on_break() {
     test_eval(
         r#"for x in [1] { try { break } finally { print -n "F" } }; print -n "D""#,
@@ -635,7 +648,16 @@ fn finally_runs_on_break() {
 }
 
 #[test]
-#[ignore = "BUG (matrix #7): `continue` skips a pending finally"]
+#[ignore = "BUG (matrix 8): `break` skips nested finallys too"]
+fn finally_runs_on_break_nested() {
+    test_eval(
+        r#"for x in [1] { try { try { break } finally { print -n "I" } } finally { print -n "O" } }; print -n "D""#,
+        Eq("IOD"),
+    )
+}
+
+#[test]
+#[ignore = "BUG (matrix 9): `continue` skips a pending finally"]
 fn finally_runs_on_continue() {
     test_eval(
         r#"for x in [1 2] { try { continue } finally { print -n "F" } }; print -n "D""#,
@@ -644,8 +666,17 @@ fn finally_runs_on_continue() {
 }
 
 #[test]
+#[ignore = "BUG (matrix 10): `continue` skips nested finallys too"]
+fn finally_runs_on_continue_nested() {
+    test_eval(
+        r#"for x in [1 2] { try { try { continue } finally { print -n "I" } } finally { print -n "O" } }; print -n "D""#,
+        Eq("IOIOD"),
+    )
+}
+
+#[test]
 fn finally_return_overrides_pending_return() {
-    // 8 (guard): a `return` in the finally wins over a `return` pending from the try.
+    // 11 (guard): a `return` in the finally wins over a `return` pending from the try.
     test_eval(
         "def foo [] { try { return 5 } finally { return 7 } }; foo",
         Eq("7"),
@@ -654,10 +685,28 @@ fn finally_return_overrides_pending_return() {
 
 #[test]
 fn finally_error_overrides_pending_return() {
-    // 9 (guard): an error in the finally wins over a `return` pending from the try.
+    // 12 (guard): an error in the finally wins over a `return` pending from the try.
     test_eval(
         r#"def foo [] { try { return 5 } finally { error make { msg: "from finally" } } }; foo"#,
         Error("from finally"),
+    )
+}
+
+#[test]
+#[ignore = "BUG (matrix 13): `break` in a finally exits the loop but leaks the try's pending return (FDR, want FDV)"]
+fn finally_break_overrides_pending_return() {
+    test_eval(
+        r#"def foo [] { for x in [1 2] { try { return "R" } finally { print -n "F"; break } }; print -n "D"; "V" }; foo | print"#,
+        Eq("FDV"),
+    )
+}
+
+#[test]
+#[ignore = "BUG (matrix 14): `continue` in a finally leaks the try's pending return (FFDR, want FFDV)"]
+fn finally_continue_overrides_pending_return() {
+    test_eval(
+        r#"def foo [] { for x in [1 2] { try { return "R" } finally { print -n "F"; continue } }; print -n "D"; "V" }; foo | print"#,
+        Eq("FFDV"),
     )
 }
 


### PR DESCRIPTION
## Description

A `finally` block should run whenever control leaves its `try`: a normal finish, a `return`, or an error. A `try` inside a loop can also be left by a `break` or `continue` in its body, and either way the try is left, so its finally runs. When the try is nested inside another `try`, an error can also be handled by the outer `catch`, and the inner finally still has to run first.

This PR makes all of that correct, and it does so by changing one thing in the engine: the eval loop used to keep two separate runtime handler stacks, one for `catch` and one for `finally`, and it checked every `catch` before any `finally`. That is why an inner finally was skipped when an outer catch was waiting. The two stacks are now one, tagged per entry, and every exit walks it in nesting order: a `return`, an error, or `exit` unwinds to the block base, a `break`/`continue` unwinds to its loop, each pending finally on the way runs, and each catch is either handled (for an error) or passed through.

### How to read the cases

Every case below is a test in `tests/eval/mod.rs`. Each runs in-process; a step of interest records itself with `"<name>" | job send 0`, and the case reports `{ ran, returned }` (or `{ ran, errored }`). So `ran` lists the steps that ran, in order, and `returned` is the value that came out. `was` is the behavior before this PR and `now` is after; a single `->` line means it already behaved that way.

### A control-flow exit leaves the try

The finally runs, the exit keeps going, and the code after the try is skipped.

**1. return, finally, code after**
```nushell
def foo [] {
    try { return "returned" } finally { "finally" | job send 0 }
    "after try" | job send 0
    "tail"
}
```
was `{ ran: [finally, after try], returned: returned }`, now `{ ran: [finally], returned: returned }`

**2. return, catch + finally, code after** the catch does not run.
was `{ ran: [finally, after try], returned: returned }`, now `{ ran: [finally], returned: returned }`

**3. return, catch, no finally** -> `{ ran: [], returned: returned }` (without a finally, `return` already skips the code after)

**4. return, finally, tail** -> `{ ran: [finally], returned: returned }` (the everyday case)

**5. return, nested finallys**
```nushell
def foo [] {
    try {
        try { return "returned" } finally { "inner" | job send 0 }
    } finally { "outer" | job send 0 }
    "after try" | job send 0
    "tail"
}
```
was `{ ran: [inner, outer, after try], returned: returned }`, now `{ ran: [inner, outer], returned: returned }`

**6. no signal, finally, code after** -> `{ ran: [finally, after try], returned: tail }` (the only case where the code after runs)

**7. break, finally**
```nushell
for x in [1] {
    try { break } finally { "finally" | job send 0 }
}
"after loop" | job send 0
```
was `{ ran: [after loop] }` (the finally never ran), now `{ ran: [finally, after loop] }`

**8. break, nested finallys** was `{ ran: [after loop] }`, now `{ ran: [inner, outer, after loop] }`

**9. continue, finally** was `{ ran: [after loop] }`, now `{ ran: [finally, finally, after loop] }`

**10. continue, nested finallys** was `{ ran: [after loop] }`, now `{ ran: [inner, outer, inner, outer, after loop] }`

### An error caught by an enclosing catch

The error unwinds to the nearest `catch`, running the finally of every `try` it passes on the way, in order, before that catch handles it. These were wrong before this PR: the outer catch was consulted first, so the inner finally was skipped.

**11. inner finally, outer catch**
```nushell
try {
    try { error make { msg: "a" } } finally { "finally" | job send 0 }
} catch { |e| $e.msg }
```
was `{ ran: [], returned: a }` (finally skipped), now `{ ran: [finally], returned: a }`

**12. catch throws, outer catch**
```nushell
try {
    try { error make { msg: "a" } }
    catch { "catch" | job send 0; error make { msg: "b" } }
    finally { "finally" | job send 0 }
} catch { |e| $e.msg }
```
The inner catch throws while the outer catch is waiting. was `{ ran: [catch], returned: b }`, now `{ ran: [catch, finally], returned: b }`

**13. nested finallys, outer catch** three finally-only `try`s deep. was `{ ran: [], returned: a }`, now `{ ran: [f1, f2], returned: a }`

**14. break in a catch, finally pending**
```nushell
for x in [1] {
    try { error make { msg: "a" } } catch { "catch" | job send 0; break } finally { "finally" | job send 0 }
}
"after loop" | job send 0
```
A `break` from inside a `catch` still leaves through that try's finally. was `{ ran: [catch, after loop] }`, now `{ ran: [catch, finally, after loop] }`

### The finally itself exits

Its exit wins over whatever the try left pending.

**15. finally returns over a pending return** -> `{ ran: [finally], returned: 7 }`
```nushell
def foo [] { try { return 5 } finally { "finally" | job send 0; return 7 } }
```

**16. finally errors over a pending return** -> `{ ran: [finally], errored: from finally }`

**17. finally breaks over a pending return**
```nushell
def foo [] {
    for x in [1 2] {
        try { return "returned" } finally { "finally" | job send 0; break }
    }
    "after loop" | job send 0
    "tail"
}
```
was `{ ran: [finally, after loop], returned: returned }` (the return leaked), now `{ ran: [finally, after loop], returned: tail }`

**18. finally continues over a pending return** was `returned: returned`, now `{ ran: [finally, finally, after loop], returned: tail }`

**19. local break in a finally keeps the pending return.** The break targets a loop nested inside the finally, so it does not leave the finally and the return survives -> `{ ran: [finally], returned: returned }`

**20. local continue in a finally keeps the pending return** -> `{ ran: [finally], returned: returned }`

### How it works: one handler stack

`catch` and `finally` now live on a single per-block handler stack, each entry tagged with its kind. `compile_try` pushes the `finally` handler before the `catch`, so a try's catch sits above its own finally and is found first for an error in the body, while the finally runs after, on the way out. That order is what fixes cases 11-14: an inner finally sitting between an error and an outer catch is above that catch on the one stack, so it runs first.

Every exit funnels through the same walk. A `return`, error, and `exit` unwind to the block base via the `run-finally` chain; `break`/`continue` unwind to their loop via a single `jump-early` that carries the count of handlers between it and the loop. The walk runs each finally and, for a non-error exit, discards each catch it passes. A `break`/`continue` that leaves a finally supersedes a pending return (17, 18 return the tail, not the leaked value); one that stays inside the finally, targeting a loop nested in it, keeps that return (19, 20).

This removes the second handler stack and the per-catch `pop-error-handler` instructions that `break`/`continue` used to emit before their jump.

## User-facing changes (Release notes)

- Fixed an issue where a `finally` block was skipped when its `try`'s error was caught by an enclosing `try`'s `catch`. The inner `finally` now runs before the outer `catch`, for any depth of nesting.
- Fixed an issue where a `break` or `continue` from inside a `catch` skipped that `try`'s `finally`.
- `finally` now runs consistently when a `break` or `continue` leaves the `try` (including nested `try`/`finally`), and the code after a `try`/`finally` is no longer run when a `return`, `break`, `continue`, or error leaves the block.

## Additional notes

Targets `cablehead:main` while the behavior is settled; not aimed at `nushell/nushell` yet.
